### PR TITLE
blog: filter posts by locale

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -1,6 +1,7 @@
+import { notFound } from "next/navigation";
 import Link from "next/link";
 import Script from "next/script";
-import { articles } from "../_assets/content";
+import { getArticlesByLocale } from "../_assets/content";
 import BadgeCategory from "../_assets/components/BadgeCategory";
 import Avatar from "../_assets/components/Avatar";
 import { getSEOTags } from "@/libs/seo";
@@ -9,15 +10,17 @@ import config from "@/config";
 export async function generateMetadata({ params }) {
   const resolvedParams = await params;
   const articleId = resolvedParams?.articleId;
-  
-  if (!articleId || !Array.isArray(articles)) {
+  const locale = resolvedParams?.locale;
+  const localeArticles = getArticlesByLocale(locale);
+
+  if (!articleId || !Array.isArray(localeArticles)) {
     return getSEOTags({
       title: "Article Not Found",
       description: "The requested article could not be found.",
     });
   }
 
-  const article = articles.find((article) => article.slug === articleId);
+  const article = localeArticles.find((article) => article.slug === articleId);
 
   if (!article) {
     return getSEOTags({
@@ -52,20 +55,22 @@ export async function generateMetadata({ params }) {
 export default async function Article({ params }) {
   const resolvedParams = await params;
   const articleId = resolvedParams?.articleId;
-  
-  if (!articleId || !Array.isArray(articles)) {
-    return <div>Article not found</div>;
+  const locale = resolvedParams?.locale;
+  const localeArticles = getArticlesByLocale(locale);
+
+  if (!articleId) {
+    notFound();
   }
 
-  const article = articles.find((article) => article.slug === articleId);
-  
+  const article = localeArticles.find((article) => article.slug === articleId);
+
   if (!article) {
-    return <div>Article not found</div>;
+    notFound();
   }
 
   const articleCategories = (article.categories || []).filter(Boolean);
-  
-  const articlesRelated = articles
+
+  const articlesRelated = localeArticles
     .filter(
       (a) =>
         a.slug !== articleId &&

--- a/app/[locale]/blog/_assets/content.js
+++ b/app/[locale]/blog/_assets/content.js
@@ -39,3 +39,6 @@ rawArticles.forEach((a, i) => {
 });
 
 export const articles = rawArticles.filter(Boolean);
+
+export const getArticlesByLocale = (locale) =>
+  articles.filter((a) => a.locale === locale);

--- a/app/[locale]/blog/_assets/posts/capacitacion-rpa-ia.js
+++ b/app/[locale]/blog/_assets/posts/capacitacion-rpa-ia.js
@@ -7,6 +7,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "capacitacion-rpa-ia",
+  locale: "es",
   title: "Capacitación en RPA e IA: Importancia de formar equipos técnicos",
   description:
     "La tecnología por sí sola no transforma empresas; las personas sí. Descubre por qué la capacitación en RPA e IA es la mejor inversión para tu equipo.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-financiera-agroindustria.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-financiera-agroindustria.js
@@ -6,6 +6,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-automatizacion-financiera-agroindustria",
+  locale: "es",
   title: "Conciliaciones financieras sin intervención manual",
   description:
     "Se automatizaron las conciliaciones bancarias y la revisión de facturas en un holding agroindustrial en Chile, reduciendo errores y liberando al equipo financiero.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-ordenes-sap-siderurgia.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-ordenes-sap-siderurgia.js
@@ -6,6 +6,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-automatizacion-ordenes-sap-siderurgia",
+  locale: "es",
   title: "Órdenes SAP automatizadas en siderurgia",
   description:
     "Se automatizó el ciclo completo de órdenes de compra en una empresa siderúrgica: desde la lectura de tickets hasta la creación de pedidos en SAP, sin intervención manual.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-cartolas-factoring-vitivinicola.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-cartolas-factoring-vitivinicola.js
@@ -6,6 +6,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-cartolas-factoring-vitivinicola",
+  locale: "es",
   title: "Cartolas y factoring automatizados en viticultura",
   description:
     "Se automatizó la carga diaria de cartolas bancarias y la gestión de factoring en una empresa vitivinícola con operaciones de exportación, reduciendo horas de trabajo a minutos.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-conciliacion-bancaria-agropecuario.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-conciliacion-bancaria-agropecuario.js
@@ -6,6 +6,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-conciliacion-bancaria-agropecuario",
+  locale: "es",
   title: "Conciliación multi-banco con ERP automatizada",
   description:
     "Se automatizó la conciliación de múltiples bancos con el ERP Finnegans en un grupo agropecuario en Argentina, ejecutando en minutos lo que antes tomaba horas.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-inteligencia-mercado-agronegocios.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-inteligencia-mercado-agronegocios.js
@@ -5,6 +5,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-inteligencia-mercado-agronegocios",
+  locale: "es",
   title: "Inteligencia de mercado automatizada para el campo",
   description:
     "Se automatizó el monitoreo diario de precios de commodities, tasas bancarias y datos macro de más de 10 fuentes públicas para una consultora de agronegocios en Argentina.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-logistica.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-logistica.js
@@ -7,6 +7,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-logistica",
+  locale: "es",
   title: "Logística y retail: 3 robots, cero errores",
   description:
     "Se automatizó el procesamiento de pedidos en una empresa de retail, integrando marketplaces, ERP y couriers con 3 robots RPA especializados.",

--- a/app/[locale]/blog/_assets/posts/caso-exito-rpa-ia-mineria-costos.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-rpa-ia-mineria-costos.js
@@ -6,6 +6,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-rpa-ia-mineria-costos",
+  locale: "es",
   title: "RPA + Agente IA: Reportes de Costos en minería",
   description:
     "Se automatizaron los reportes de costos de una empresa minera de cobre en Chile con RPA y un agente de IA que responde preguntas en lenguaje natural, eliminando la dependencia de una sola persona.",

--- a/app/[locale]/blog/_assets/posts/chatbots-ia-ecommerce.js
+++ b/app/[locale]/blog/_assets/posts/chatbots-ia-ecommerce.js
@@ -7,6 +7,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "chatbots-ia-ecommerce",
+  locale: "es",
   title: "Chatbots con IA para ventas y soporte: Cómo los asistentes virtuales mejoran el e-commerce",
   description:
     "Descubre cómo los chatbots impulsados por IA están revolucionando el e-commerce, mejorando la atención al cliente y aumentando las ventas 24/7.",

--- a/app/[locale]/blog/_assets/posts/como-calcular-el-roi-en-proyectos-rpa.js
+++ b/app/[locale]/blog/_assets/posts/como-calcular-el-roi-en-proyectos-rpa.js
@@ -8,6 +8,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 export const post = {
   // The unique slug to use in the URL. It's also used to generate the canonical URL.
   slug: "como-calcular-el-roi-en-proyectos-rpa",
+  locale: "es",
   // The title to display in the article page (h1). Less than 60 characters. It's also used to generate the meta title.
   title: "¿Cómo Calcular el ROI en Proyectos de Automatización?",
   // The description of the article to display in the article page. Up to 160 characters. It's also used to generate the meta description.

--- a/app/[locale]/blog/_assets/posts/porque-elegir-rocketbot.js
+++ b/app/[locale]/blog/_assets/posts/porque-elegir-rocketbot.js
@@ -7,6 +7,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "porque-elegir-rocketbot",
+  locale: "es",
   title: "¿Por qué elegir Rocketbot para tu automatización?",
   description:
     "Descubre por qué Rocketbot es la mejor herramienta para automatizar tus procesos. Con Rocketbot, puedes automatizar tus procesos de manera sencilla y eficiente.",

--- a/app/[locale]/blog/_assets/posts/que-es-rpa.js
+++ b/app/[locale]/blog/_assets/posts/que-es-rpa.js
@@ -7,6 +7,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "que-es-rpa",
+  locale: "es",
   title: "¿Qué es RPA? Introducción a la automatización de procesos empresariales",
   description:
     "Descubre qué es RPA (Automatización Robótica de Procesos), cómo funciona y por qué es clave para la transformación digital de tu empresa.",

--- a/app/[locale]/blog/_assets/posts/tendencias-automatizacion-2025.js
+++ b/app/[locale]/blog/_assets/posts/tendencias-automatizacion-2025.js
@@ -7,6 +7,7 @@ import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "tendencias-automatizacion-2025",
+  locale: "es",
   title: "Tendencias 2025 en Automatización e IA: Qué esperar en Latinoamérica",
   description:
     "Exploramos las tendencias tecnológicas que definirán el 2025 en LatAm: Hiperautomatización, IA Generativa y la democratización del desarrollo de software.",

--- a/app/[locale]/blog/author/[authorId]/page.js
+++ b/app/[locale]/blog/author/[authorId]/page.js
@@ -1,12 +1,13 @@
 import Image from "next/image";
 import { authors } from "../../_assets/authors";
-import { articles } from "../../_assets/content";
+import { getArticlesByLocale } from "../../_assets/content";
 import CardArticle from "../../_assets/components/CardArticle";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
 
 export async function generateMetadata({ params }) {
-  const author = authors.find((author) => author.slug === params.authorId);
+  const { authorId } = await params;
+  const author = authors.find((author) => author.slug === authorId);
 
   return getSEOTags({
     title: `${author.name}, Author at ${config.appName}'s Blog`,
@@ -16,8 +17,9 @@ export async function generateMetadata({ params }) {
 }
 
 export default async function Author({ params }) {
-  const author = authors.find((author) => author.slug === params.authorId);
-  const articlesByAuthor = articles
+  const { authorId, locale } = await params;
+  const author = authors.find((author) => author.slug === authorId);
+  const articlesByAuthor = getArticlesByLocale(locale)
     .filter((article) => article.author.slug === author.slug)
     .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
 

--- a/app/[locale]/blog/category/[categoryId]/page.js
+++ b/app/[locale]/blog/category/[categoryId]/page.js
@@ -1,14 +1,13 @@
 import { categories } from "../../_assets/categories";
-import { articles } from "../../_assets/content";
+import { getArticlesByLocale } from "../../_assets/content";
 import CardArticle from "../../_assets/components/CardArticle";
 import CardCategory from "../../_assets/components/CardCategory";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
 
 export async function generateMetadata({ params }) {
-  const category = categories.find(
-    (category) => category.slug === params.categoryId
-  );
+  const { categoryId } = await params;
+  const category = categories.find((category) => category.slug === categoryId);
 
   return getSEOTags({
     title: `${category.title} | Blog by ${config.appName}`,
@@ -18,10 +17,9 @@ export async function generateMetadata({ params }) {
 }
 
 export default async function Category({ params }) {
-  const category = categories.find(
-    (category) => category.slug === params.categoryId
-  );
-  const articlesInCategory = articles
+  const { categoryId, locale } = await params;
+  const category = categories.find((category) => category.slug === categoryId);
+  const articlesInCategory = getArticlesByLocale(locale)
     .filter((article) =>
       article.categories.map((c) => c.slug).includes(category.slug)
     )

--- a/app/[locale]/blog/page.js
+++ b/app/[locale]/blog/page.js
@@ -1,4 +1,4 @@
-import { articles } from "./_assets/content";
+import { getArticlesByLocale } from "./_assets/content";
 import { categories } from "./_assets/categories.js";
 import CardArticle from "./_assets/components/CardArticle";
 import CardCategory from "./_assets/components/CardCategory";
@@ -12,8 +12,9 @@ export const metadata = getSEOTags({
   canonicalUrlRelative: "/blog",
 });
 
-export default async function Blog() {
-  const articlesToDisplay = articles
+export default async function Blog({ params }) {
+  const { locale } = await params;
+  const articlesToDisplay = getArticlesByLocale(locale)
     .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
   return (
     <>


### PR DESCRIPTION
Add a `locale` field to every blog post (all existing ones tagged "es") and filter the blog list, article, author and category pages by the current request locale so each language shows only its own posts.

- `_assets/posts/*.js`: add `locale: "es"` to the 13 existing posts.
- `_assets/content.js`: export `getArticlesByLocale(locale)` helper.
- `/blog/page.js`: read locale from params, filter list.
- `/blog/[articleId]/page.js`: filter by locale; a post requested under the wrong locale now triggers notFound() instead of rendering. Related posts are also scoped to the current locale.
- `/blog/author/[authorId]/page.js` and `/blog/category/[categoryId]/page.js`: await params (Next 15+ API), read locale, scope the listing to that locale.