### PR TITLE
Add markdown content negotiation and custom robots.txt

### DIFF
--- a/app/api/markdown/route.js
+++ b/app/api/markdown/route.js
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { NodeHtmlMarkdown } from "node-html-markdown";
+import { routing } from "@/i18n/routing";
+
+export const dynamic = "force-dynamic";
+
+const LOCALE_PREFIX = new RegExp(`^/(${routing.locales.join("|")})(/|$)`);
+
+function normalizePath(path) {
+  if (!path || !path.startsWith("/")) return `/${routing.defaultLocale}`;
+  if (LOCALE_PREFIX.test(path)) return path;
+  return `/${routing.defaultLocale}${path === "/" ? "" : path}`;
+}
+
+function stripNoise(html) {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, "");
+}
+
+function extractMain(html) {
+  const mainMatch = html.match(/<main\b[^>]*>([\s\S]*?)<\/main>/i);
+  if (mainMatch) return mainMatch[1];
+  const bodyMatch = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+  if (bodyMatch) return bodyMatch[1];
+  return html;
+}
+
+export async function GET(request) {
+  const requestUrl = new URL(request.url);
+  const rawPath =
+    request.headers.get("x-md-source-path") ||
+    requestUrl.searchParams.get("path") ||
+    "/";
+  const rawSearch = request.headers.get("x-md-source-search") || "";
+  const targetPath = normalizePath(rawPath);
+
+  const forwardUrl = new URL(targetPath + rawSearch, requestUrl.origin);
+
+  let upstream;
+  try {
+    upstream = await fetch(forwardUrl, {
+      headers: { Accept: "text/html" },
+      redirect: "follow",
+    });
+  } catch {
+    return new NextResponse("Upstream fetch failed", { status: 502 });
+  }
+
+  if (!upstream.ok) {
+    return new NextResponse(`Upstream returned ${upstream.status}`, {
+      status: upstream.status,
+    });
+  }
+
+  const html = await upstream.text();
+  const content = stripNoise(extractMain(html));
+  const markdown = NodeHtmlMarkdown.translate(content).trim() + "\n";
+  const tokens = Math.ceil(markdown.length / 4);
+
+  return new NextResponse(markdown, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "x-markdown-tokens": String(tokens),
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+      Vary: "Accept",
+    },
+  });
+}

--- a/app/robots.txt/route.js
+++ b/app/robots.txt/route.js
@@ -1,0 +1,23 @@
+export const dynamic = "force-static";
+
+export function GET() {
+  const siteUrl = process.env.SITE_URL || "https://robotipy.com";
+  const body = [
+    "# Content signals — https://contentsignals.org/",
+    "Content-Signal: search=yes, ai-train=no, ai-input=no",
+    "",
+    "User-agent: *",
+    "Allow: /",
+    "",
+    `Sitemap: ${siteUrl}/sitemap.xml`,
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,26 @@
 import createMiddleware from "next-intl/middleware";
+import { NextResponse } from "next/server";
 import { routing } from "./i18n/routing";
 
-export default createMiddleware(routing);
+const intlMiddleware = createMiddleware(routing);
+
+const MARKDOWN_ACCEPT = /(^|,\s*)text\/markdown(\s*;|\s*,|\s*$)/i;
+
+export default function middleware(request) {
+  const accept = request.headers.get("accept") || "";
+  if (request.method === "GET" && MARKDOWN_ACCEPT.test(accept)) {
+    const url = request.nextUrl.clone();
+    const originalPath = request.nextUrl.pathname;
+    const originalSearch = request.nextUrl.search;
+    url.pathname = "/api/markdown";
+    url.search = "";
+    const headers = new Headers(request.headers);
+    headers.set("x-md-source-path", originalPath);
+    headers.set("x-md-source-search", originalSearch);
+    return NextResponse.rewrite(url, { request: { headers } });
+  }
+  return intlMiddleware(request);
+}
 
 export const config = {
   matcher: [

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -3,7 +3,7 @@ const defaultLocale = "es";
 
 module.exports = {
   siteUrl: process.env.SITE_URL || "https://robotipy.com",
-  generateRobotsTxt: true,
+  generateRobotsTxt: false,
   exclude: ["/twitter-image.*", "/opengraph-image.*", "/icon.*"],
   alternateRefs: locales.map((l) => ({
     href: `${process.env.SITE_URL || "https://robotipy.com"}/${l}`,

--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,10 @@ const nextConfig = {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=()",
           },
+          {
+            key: "Vary",
+            value: "Accept",
+          },
         ],
       },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "next-plausible": "^3.12.0",
         "next-sitemap": "^4.2.3",
         "nextjs-toploader": "^1.6.11",
+        "node-html-markdown": "^1.3.0",
         "nodemailer": "^6.10.1",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
@@ -2871,6 +2872,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3168,6 +3175,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-selector-tokenizer": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.8.0.tgz",
@@ -3176,6 +3199,18 @@
       "dependencies": {
         "cssesc": "^3.0.0",
         "fastparse": "^1.1.2"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -3358,6 +3393,61 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3407,6 +3497,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4654,6 +4756,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hermes-estree": {
@@ -5977,6 +6088,28 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-html-markdown": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
+      "integrity": "sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-html-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -6013,6 +6146,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
     },
     "node_modules/oauth4webapi": {
       "version": "2.10.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next-intl": "^4.9.1",
     "next-plausible": "^3.12.0",
     "next-sitemap": "^4.2.3",
+    "node-html-markdown": "^1.3.0",
     "nextjs-toploader": "^1.6.11",
     "nodemailer": "^6.10.1",
     "react": "^19.2.3",


### PR DESCRIPTION
## Summary
This PR adds content negotiation support for markdown format and implements a custom robots.txt endpoint with content signals metadata.

## Key Changes

- **Markdown API Endpoint** (`app/api/markdown/route.js`): New API route that converts HTML content to markdown format
  - Accepts requests with `Accept: text/markdown` header
  - Fetches upstream HTML content and converts it using `node-html-markdown`
  - Strips script, style, and noscript tags to remove noise
  - Extracts main content from `<main>` or `<body>` tags
  - Returns markdown with token count estimation in response headers
  - Implements 5-minute client cache and 1-hour CDN cache

- **Middleware Enhancement** (`middleware.js`): Added content negotiation logic
  - Detects requests with `Accept: text/markdown` header
  - Rewrites matching requests to the markdown API endpoint
  - Preserves original path and query parameters via custom headers
  - Maintains existing i18n middleware functionality

- **Custom Robots.txt** (`app/robots.txt/route.js`): New endpoint replacing auto-generated robots.txt
  - Includes Content-Signal metadata indicating no AI training/input allowed
  - Provides sitemap reference
  - Configurable via `SITE_URL` environment variable
  - Static generation with 1-hour client and 1-day CDN cache

- **Configuration Updates**:
  - Disabled auto-generation of robots.txt in `next-sitemap.config.js`
  - Added `Vary: Accept` header to all responses in `next.config.js`
  - Added `node-html-markdown` dependency to `package.json`

## Implementation Details

The markdown conversion respects locale prefixes and normalizes paths to include the default locale when needed. The middleware uses regex pattern matching to efficiently detect markdown requests without impacting other traffic. Token estimation uses a simple 4-character average for rough token counting.

https://claude.ai/code/session_01TXExdBLDj4cVDU4q3tqfQ5