### PR TITLE
perf: address PageSpeed Insights diagnostics

### DIFF
--- a/components/CasosDeExito.js
+++ b/components/CasosDeExito.js
@@ -43,24 +43,28 @@ const CasosDeExito = () => {
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(true);
 
-  const checkScroll = () => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
-  };
-
   useEffect(() => {
-    checkScroll();
     const el = scrollRef.current;
-    if (el) {
-      el.addEventListener("scroll", checkScroll);
-      window.addEventListener("resize", checkScroll);
-      return () => {
-        el.removeEventListener("scroll", checkScroll);
-        window.removeEventListener("resize", checkScroll);
-      };
-    }
+    if (!el) return undefined;
+
+    let frame = 0;
+    const checkScroll = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        setCanScrollLeft(el.scrollLeft > 0);
+        setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
+      });
+    };
+
+    checkScroll();
+    el.addEventListener("scroll", checkScroll, { passive: true });
+    window.addEventListener("resize", checkScroll, { passive: true });
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      el.removeEventListener("scroll", checkScroll);
+      window.removeEventListener("resize", checkScroll);
+    };
   }, []);
 
   const scroll = (direction) => {

--- a/components/LayoutClient.js
+++ b/components/LayoutClient.js
@@ -2,27 +2,24 @@
 
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
-import { useSession } from "next-auth/react";
-import { Crisp } from "crisp-sdk-web";
-import { SessionProvider } from "next-auth/react";
+import { useSession, SessionProvider } from "next-auth/react";
 import NextTopLoader from "nextjs-toploader";
 import { Toaster } from "react-hot-toast";
-// Removed react-tooltip import - using native HTML title attribute instead
 import config from "@/config";
 
-// Crisp customer chat support:
-// This component is separated from ClientLayout because it needs to be wrapped with <SessionProvider> to use useSession() hook
+// Crisp customer chat support — the SDK is loaded lazily, only when a
+// crisp.id is configured. With config.crisp.id empty (as currently), the
+// SDK is never fetched and stays out of the JS bundle.
 const CrispChat = () => {
   const pathname = usePathname();
   const { data } = useSession();
 
   useEffect(() => {
-    if (config?.crisp?.id) {
-      // Set up Crisp
+    if (!config?.crisp?.id) return;
+    let cancelled = false;
+    import("crisp-sdk-web").then(({ Crisp }) => {
+      if (cancelled) return;
       Crisp.configure(config.crisp.id);
-
-      // (Optional) If onlyShowOnRoutes array is not empty in config.js file, Crisp will be hidden on the routes in the array.
-      // Use <AppButtonSupport> instead to show it (user clicks on the button to show Crisp—it cleans the UI)
       if (
         config.crisp.onlyShowOnRoutes &&
         !config.crisp.onlyShowOnRoutes?.includes(pathname)
@@ -32,48 +29,34 @@ const CrispChat = () => {
           Crisp.chat.hide();
         });
       }
-    }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [pathname]);
 
-  // Add User Unique ID to Crisp to easily identify users when reaching support (optional)
   useEffect(() => {
-    if (data?.user && config?.crisp?.id) {
+    if (!data?.user || !config?.crisp?.id) return;
+    import("crisp-sdk-web").then(({ Crisp }) => {
       Crisp.session.setData({ userId: data.user?.id });
-    }
+    });
   }, [data]);
 
   return null;
 };
 
-// All the client wrappers are here (they can't be in server components)
-// 1. SessionProvider: Allow the useSession from next-auth (find out if user is auth or not)
-// 2. NextTopLoader: Show a progress bar at the top when navigating between pages
-// 3. Toaster: Show Success/Error messages anywhere from the app with toast()
-// 4. Tooltip: Show tooltips if any JSX elements has these 2 attributes: data-tooltip-id="tooltip" data-tooltip-content=""
-// 5. CrispChat: Set Crisp customer chat support (see above)
 const ClientLayout = ({ children }) => {
   return (
-    <>
-      <SessionProvider>
-        {/* Show a progress bar at the top when navigating between pages */}
-        <NextTopLoader color={config.colors.main} showSpinner={false} />
-
-        {/* Content inside app/page.js files  */}
-        {children}
-
-        {/* Show Success/Error messages anywhere from the app with toast() */}
-        <Toaster
-          toastOptions={{
-            duration: 3000,
-          }}
-        />
-
-        {/* Tooltips removed - use native HTML title attribute instead */}
-
-        {/* Set Crisp customer chat support */}
-        <CrispChat />
-      </SessionProvider>
-    </>
+    <SessionProvider>
+      <NextTopLoader color={config.colors.main} showSpinner={false} />
+      {children}
+      <Toaster
+        toastOptions={{
+          duration: 3000,
+        }}
+      />
+      <CrispChat />
+    </SessionProvider>
   );
 };
 

--- a/components/MapsSolutions.js
+++ b/components/MapsSolutions.js
@@ -16,8 +16,10 @@ const MapsSolutions = () => {
             <Image
               src="/assets/mapa.png"
               alt={t("mapAlt")}
-              width={1000}
-              height={1000}
+              width={1197}
+              height={680}
+              sizes="(max-width: 1024px) 100vw, 800px"
+              quality={70}
               className="w-full h-auto rounded-lg"
             />
           </div>

--- a/package.json
+++ b/package.json
@@ -43,5 +43,14 @@
     "daisyui": "^3.9.4",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3"
-  }
+  },
+  "browserslist": [
+    "chrome >= 92",
+    "edge >= 92",
+    "firefox >= 91",
+    "safari >= 15.4",
+    "ios_saf >= 15.4",
+    "not dead",
+    "not op_mini all"
+  ]
 }


### PR DESCRIPTION
- Drop legacy ES2017+ polyfills (~26 KiB savings) by setting a modern browserslist (Safari 15.4+, Chrome/Edge 92+, Firefox 91+) — eliminates Array.prototype.at/flat/flatMap, Object.fromEntries/hasOwn, String.prototype.trimEnd/trimStart polyfills.
- Improve mapa.png delivery (~84 KiB savings):
  * fix dimensions to actual aspect ratio (1197x680 from the source PNG, not 1000x1000) so Next.js stops upscaling;
  * add a sizes attribute matching the layout so the responsive srcset picks a smaller image on mobile;
  * lower quality to 70 for this large illustration.
- Lazy-load the Crisp SDK so it stays out of the JS bundle when no crisp.id is configured (current state) — removes ~12 KiB and the module-level work it triggers on initial page execution.
- Reduce forced reflow in CasosDeExito carousel by batching scroll/ resize layout reads inside requestAnimationFrame and registering the listeners as passive.