### PR TITLE
Remove stale image TODO in que-es-rpa post

### DIFF
--- a/app/[locale]/blog/_assets/posts/que-es-rpa.js
+++ b/app/[locale]/blog/_assets/posts/que-es-rpa.js
@@ -2,7 +2,7 @@ import Image from "next/image";
 import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
   import { styles } from "../styles";
-  import thumbnail from "@/public/blog/que-es-rpa/header.jpeg"; // TODO: Replace with specific image
+import thumbnail from "@/public/blog/que-es-rpa/header.jpeg";
 import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {


### PR DESCRIPTION
## Summary
- Drops the `// TODO: Replace with specific image` comment on the thumbnail import in `que-es-rpa.js`.
- The post-specific image already exists at `public/blog/que-es-rpa/header.jpeg`, and other posts (e.g. `como-calcular-el-roi-en-proyectos-rpa.js`) follow the same pattern with no TODO marker.
- Also fixes the stray leading indentation on that import line so it lines up with the rest of the import block.

## Test plan
- [ ] Verify the blog list and the `/blog/que-es-rpa` page still render the expected thumbnail.
- [ ] Confirm `next build` / lint passes with the import unchanged in behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8KJQonYognrf7V6xKSfrm)_