### PR TITLE
fix(blog): separa números del diagrama RPA y reemplaza em-dashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+Instrucciones permanentes para Claude (y agentes asistidos por IA) al
+trabajar en este repositorio.
+
+## Stack
+
+- Next.js 16 (App Router, Turbopack) + React + Tailwind + daisyUI.
+- i18n con `next-intl`, locale `[locale]` en las rutas.
+- Blog estático con posts JSX en `app/[locale]/blog/_assets/posts/`,
+  registrados en `app/[locale]/blog/_assets/content.js`.
+
+## Reglas de contenido (obligatorias)
+
+Consultar siempre `CONTENT_GUIDELINES.md` antes de redactar copy o
+artículos. Resumen de lo no negociable:
+
+- **Prohibido em-dash (`—`)**. Usar coma, paréntesis o dos puntos.
+- **Prohibidos emojis como viñeta** (`❌`, `✅`, `⚠️`, `💡`, etc.) ni
+  al inicio de ítems de listas. Emojis decorativos en headers de
+  tarjetas se permiten con moderación.
+- **En-dash (`–`) solo para rangos numéricos** (`6–8 horas`).
+- Tono directo, segunda persona, sin muletillas tipo "imagina por un
+  momento", "en este artículo exploraremos", "no es magia, es...".
+- Evitar inicios genéricos de IA y cierres motivacionales vacíos.
+
+## Reglas de código
+
+- Mantener los posts del blog como Server Components. Si se necesita
+  interactividad, preferir HTML nativo (`<details>/<summary>` para
+  acordeones) antes que `"use client"`.
+- Paleta Robotipy: `primary #00182B`, `accent rgb(3,150,149)` (teal),
+  fondo oscuro. No introducir colores nuevos sin justificación.
+- Diagramas SVG: dejar al menos ~8 px de separación entre círculos
+  numerados y el texto del título; usar `textAnchor="start"` cuando el
+  texto pueda solaparse con elementos a la izquierda.
+- Tablas: envolver en `overflow-x-auto` para mobile.
+- No agregar comentarios redundantes ni docstrings extensos.
+
+## Flujo de trabajo
+
+- Desarrollar siempre en branch separada (`claude/<descripcion>`).
+- Hacer commits con mensajes en español, en imperativo presente,
+  describiendo el "por qué" cuando sea relevante.
+- Crear el PR como "ready for review" (no draft) apuntando a `main`.
+- Validar JSX con SWC o `next build` antes de pushear cuando el
+  entorno lo permita; si falla por falta de internet (Google Fonts),
+  declararlo explícitamente.
+
+## Estructura del blog
+
+- Autores: `app/[locale]/blog/_assets/authors.js`.
+- Categorías: `app/[locale]/blog/_assets/categories.js`.
+- Estilos compartidos de contenido: `app/[locale]/blog/_assets/styles.js`.
+- Página dinámica: `app/[locale]/blog/[articleId]/page.js`.
+- Cada post exporta `{ slug, locale, title, description, categories,
+  author, publishedAt, image, content }`.
+
+## Antes de cerrar una tarea
+
+- Repasar el checklist final de `CONTENT_GUIDELINES.md`.
+- Verificar que no se introdujeron em-dashes ni emojis-viñeta.
+- Confirmar que el post está registrado en `content.js`.

--- a/CONTENT_GUIDELINES.md
+++ b/CONTENT_GUIDELINES.md
@@ -1,0 +1,73 @@
+# Directrices de contenido — Robotipy
+
+Reglas de estilo para artículos de blog, copy de landing y cualquier
+texto generado (incluyendo el asistido por IA). El objetivo es que el
+contenido suene humano, profesional y consistente con la marca.
+
+## 1. Puntuación
+
+- **No usar em-dashes (`—`)**. Reemplazar por:
+  - Coma cuando se trate de un inciso o pausa.
+  - Paréntesis cuando se introduzca una aclaración.
+  - Dos puntos cuando se introduzca una explicación o lista.
+- **En-dashes (`–`) sí se permiten** únicamente en rangos numéricos:
+  `6–8 horas`, `2–4 semanas`, `1–3 horas/semana`.
+- Evitar el uso de guion largo como signo de atribución en citas:
+  preferir formato `Nombre, cargo` sin guion inicial.
+
+## 2. Emojis e íconos
+
+- **No usar emojis como viñeta** ni al inicio de los ítems de una lista.
+  En particular, evitar `❌`, `✅`, `⚠️`, `🚨`, `💡`, etc., porque dan
+  un tono "AI-generated".
+- Emojis decorativos en encabezados de tarjetas o secciones (ej.
+  `🏦 Banca y Finanzas`, `🌾 Agroindustria`) se permiten con moderación
+  cuando aportan identificación visual y no sustituyen una palabra.
+- Para indicar negación o afirmación, preferir el lenguaje:
+  `No es...`, `Sí, ...`, en lugar de `❌ No es...` o `✅ Sí, ...`.
+
+## 3. Tono
+
+- Directo y conversacional, sin sonar promocional ni "robotizado".
+- Evitar muletillas típicas de IA: "en este artículo exploraremos...",
+  "el mundo cambia constantemente...", "imagina por un momento...",
+  "no es magia, es...".
+- Preferir frases cortas. Romper párrafos largos.
+- Hablar en segunda persona (`tu empresa`, `tus procesos`).
+
+## 4. Datos y cifras
+
+- Acompañar siempre las estadísticas con contexto o fuente cuando sea
+  posible. Si la cifra es referencial, decirlo explícitamente.
+- Formato de moneda chilena: `CLP $1.000.000` (punto como separador
+  de miles).
+
+## 5. Estructura típica de un artículo del blog
+
+1. Intro corta (2–4 párrafos) con el problema y promesa del artículo.
+2. Bloque de estadísticas clave (opcional).
+3. Tabla de contenidos enlazada por anclas.
+4. Secciones numeradas con `h2`.
+5. Callouts, tablas y diagramas SVG cuando aporten claridad.
+6. FAQ al final con `<details>/<summary>`.
+7. CTA al final hacia `/contact-us` o un caso de éxito.
+
+## 6. Componentes visuales
+
+- Paleta: `primary #00182B`, `accent rgb(3,150,149)` (teal), fondo oscuro.
+- Tarjetas y callouts: borde sutil con `border-white/10` y fondo
+  `bg-white/5`.
+- Strong/destacados: usar `styles.strong` (texto en verde `text-success`).
+- Diagramas SVG: separar siempre números de los títulos para evitar
+  superposición; los círculos deben tener al menos 8 px de margen
+  respecto al texto.
+
+## 7. Checklist antes de publicar
+
+- [ ] No quedan em-dashes (`—`) en el texto.
+- [ ] No hay emojis como viñeta (`❌`, `✅`, etc.).
+- [ ] Los rangos numéricos usan en-dash (`–`).
+- [ ] Las tablas no se cortan en mobile (envolver en `overflow-x-auto`).
+- [ ] El FAQ está implementado con `<details>` (no requiere JS cliente).
+- [ ] Las imágenes tienen `alt` descriptivo.
+- [ ] El CTA final apunta a una página existente.

--- a/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
+++ b/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
@@ -201,10 +201,10 @@ export const post = {
 
         <p className={styles.p}>La clave está en entender qué <strong className={styles.strong}>no</strong> es RPA:</p>
         <ul className={styles.ul}>
-          <li className={styles.li}>❌ No es un robot físico ni mecánico.</li>
-          <li className={styles.li}>❌ No es inteligencia artificial (aunque puede combinarse con ella).</li>
-          <li className={styles.li}>❌ No modifica ni reemplaza los sistemas que ya usas.</li>
-          <li className={styles.li}>❌ No requiere que cambies tu software actual.</li>
+          <li className={styles.li}>No es un robot físico ni mecánico.</li>
+          <li className={styles.li}>No es inteligencia artificial (aunque puede combinarse con ella).</li>
+          <li className={styles.li}>No modifica ni reemplaza los sistemas que ya usas.</li>
+          <li className={styles.li}>No requiere que cambies tu software actual.</li>
         </ul>
 
         <p className={styles.p}>

--- a/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
+++ b/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
@@ -191,7 +191,7 @@ export const post = {
             <strong className={styles.strong}>Ese colaborador es una máquina de seguir instrucciones.</strong>
           </p>
           <p className={styles.p}>
-            El problema: se equivoca, se cansa, tarda, está ausente algunos días y —seamos honestos— odia esa tarea.
+            El problema: se equivoca, se cansa, tarda, está ausente algunos días y (seamos honestos) odia esa tarea.
           </p>
           <p className={styles.p}>
             <strong className={styles.strong}>Un bot RPA es ese colaborador, pero digital.</strong> Hace exactamente los
@@ -252,9 +252,9 @@ export const post = {
             <circle cx="572" cy="52" r="14" fill="#00182B" />
             <text x="572" y="57" textAnchor="middle" fill="white" fontSize="13" fontWeight="700" fontFamily="Arial">3</text>
 
-            <text x="110" y="58" textAnchor="middle" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">El bot se activa</text>
-            <text x="380" y="58" textAnchor="middle" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Accede a los sistemas</text>
-            <text x="650" y="58" textAnchor="middle" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Extrae los datos</text>
+            <text x="55" y="57" textAnchor="start" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">El bot se activa</text>
+            <text x="325" y="57" textAnchor="start" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Accede a los sistemas</text>
+            <text x="595" y="57" textAnchor="start" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Extrae los datos</text>
 
             <text x="110" y="78" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">Automáticamente a la</text>
             <text x="110" y="93" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">hora programada o al</text>
@@ -283,13 +283,13 @@ export const post = {
             <circle cx="32" cy="212" r="14" fill="#16a34a" />
             <text x="32" y="217" textAnchor="middle" fill="white" fontSize="13" fontWeight="700" fontFamily="Arial">6</text>
 
-            <text x="650" y="218" textAnchor="middle" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Procesa y compara</text>
-            <text x="380" y="218" textAnchor="middle" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Registra y notifica</text>
-            <text x="110" y="218" textAnchor="middle" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Reporta y cierra</text>
+            <text x="595" y="217" textAnchor="start" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Procesa y compara</text>
+            <text x="325" y="217" textAnchor="start" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Registra y notifica</text>
+            <text x="55" y="217" textAnchor="start" fill="#ffffff" fontSize="14" fontWeight="700" fontFamily="Arial">Reporta y cierra</text>
 
             <text x="650" y="238" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">Aplica las reglas del</text>
             <text x="650" y="253" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">proceso: si coincide OK,</text>
-            <text x="650" y="268" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">si no — genera alerta</text>
+            <text x="650" y="268" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">si no, genera alerta</text>
 
             <text x="380" y="238" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">Ingresa los datos en el</text>
             <text x="380" y="253" textAnchor="middle" fill="#cfd8dc" fontSize="11.5" fontFamily="Arial">sistema contable y envía</text>
@@ -489,7 +489,7 @@ export const post = {
                 <td className={ui.td}><strong className={styles.strong}>RPA</strong></td>
                 <td className={ui.td}>Automatiza pasos repetitivos en cualquier sistema, sin API ni código</td>
                 <td className={ui.td}>No &quot;aprende&quot; solo, requiere reglas claras</td>
-                <td className={ui.td}>—</td>
+                <td className={ui.td}>N/A</td>
               </tr>
               <tr>
                 <td className={ui.td}><strong className={styles.strong}>Macros de Excel</strong></td>
@@ -501,19 +501,19 @@ export const post = {
                 <td className={ui.td}><strong className={styles.strong}>Inteligencia Artificial (IA)</strong></td>
                 <td className={ui.td}>Entiende lenguaje, imágenes, contexto, toma decisiones</td>
                 <td className={ui.td}>No ejecuta pasos operativos por sí sola</td>
-                <td className={ui.td}><span className={ui.badge("green")}>Sí — combo poderoso</span></td>
+                <td className={ui.td}><span className={ui.badge("green")}>Sí (combo poderoso)</span></td>
               </tr>
               <tr>
                 <td className={ui.td}><strong className={styles.strong}>Integración de sistemas (API)</strong></td>
                 <td className={ui.td}>Conecta sistemas a nivel técnico, muy robusta</td>
                 <td className={ui.td}>Requiere que ambos sistemas tengan API. Costosa de desarrollar.</td>
-                <td className={ui.td}><span className={ui.badge("green")}>Sí — complementarios</span></td>
+                <td className={ui.td}><span className={ui.badge("green")}>Sí (complementarios)</span></td>
               </tr>
               <tr>
                 <td className={ui.td}><strong className={styles.strong}>ERP personalizado</strong></td>
                 <td className={ui.td}>Centraliza todos los procesos del negocio</td>
                 <td className={ui.td}>Muy costoso, implementación de meses o años</td>
-                <td className={ui.td}><span className={ui.badge("green")}>Sí — RPA llena los gaps</span></td>
+                <td className={ui.td}><span className={ui.badge("green")}>Sí (RPA llena los gaps)</span></td>
               </tr>
             </tbody>
           </table>
@@ -535,12 +535,12 @@ export const post = {
       {/* SECCIÓN 6 */}
       <section id="para-pymes" className="space-y-3 scroll-mt-24">
         <h2 className={styles.h2}>6. ¿RPA es solo para empresas grandes?</h2>
-        <p className={styles.p}>Esta es la creencia que más nos encontramos —y la que más nos gusta desmentir.</p>
+        <p className={styles.p}>Esta es la creencia que más nos encontramos, y la que más nos gusta desmentir.</p>
 
         <blockquote className={ui.quote}>
           &quot;Pensé que el RPA era solo para el Banco de Chile o para grandes multilatinas. Cuando vi que podíamos
           implementarlo en nuestra PyME por una fracción de lo que esperaba, fue un cambio de juego.&quot;
-          <cite className={ui.cite}>— Gerente de operaciones, empresa de servicios profesionales en Santiago</cite>
+          <cite className={ui.cite}>Gerente de operaciones, empresa de servicios profesionales en Santiago</cite>
         </blockquote>
 
         <p className={styles.p}>

--- a/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
+++ b/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
@@ -22,7 +22,7 @@ const ui = {
   tocList: "list-decimal pl-5 space-y-1.5 text-white/90 text-[15px]",
 
   analogy:
-    "relative rounded-xl border-2 border-dashed border-accent bg-white/5 p-7 my-8 space-y-3",
+    "relative rounded-xl border-2 border-dashed border-accent bg-white/5 pt-10 px-7 pb-7 my-8 space-y-3",
   analogyTag:
     "absolute -top-3 left-6 bg-accent text-white text-[11px] font-bold uppercase tracking-wider rounded-full px-3 py-0.5",
 


### PR DESCRIPTION
## Resumen

Ajustes al artículo "RPA con Peras y Manzanas":

- **Diagrama "Cómo funciona un bot RPA"**: los títulos de cada paso se acoplaban visualmente al círculo numerado. Cambié `textAnchor` de `middle` a `start` para los 6 títulos, posicionados justo a la derecha del círculo (x=55/325/595) → ahora hay separación clara.
- **Em-dashes (—) reemplazados** por comas o paréntesis según el contexto:
  - "—seamos honestos—" → "(seamos honestos)"
  - "si no — genera alerta" → "si no, genera alerta"
  - "Sí — combo poderoso/complementarios/RPA llena los gaps" → con paréntesis
  - "—y la que más nos gusta desmentir" → ", y la que más..."
  - "— Gerente de operaciones..." → sin guion inicial
  - Celda placeholder de tabla "—" → "N/A"

## Test plan

- [ ] `/es/blog/rpa-con-peras-y-manzanas`: verificar diagrama de los 6 pasos, los números y títulos no se solapan.
- [ ] Buscar (Ctrl+F) "—" en la página y confirmar que no quedan em-dashes (los en-dashes `–` de rangos numéricos como "6–8 horas" se conservan).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Poambb4fK61bAT5WLABGkR)_