### PR TITLE
feat(blog): banner propio para "RPA con Peras y Manzanas"

### DIFF
--- a/app/[locale]/blog/_assets/authors.js
+++ b/app/[locale]/blog/_assets/authors.js
@@ -1,4 +1,5 @@
 import daniloToroImg from "./images/authors/danilo-toro.png";
+import gabrielToroImg from "./images/authors/gabriel-toro.jpeg";
 
 // ==================================================================================================================================================================
 // BLOG AUTHORS 📝
@@ -68,7 +69,7 @@ export const authors = [
     job: "Equipo Robotipy",
     description:
       "Gabriel forma parte del equipo de Robotipy, especializado en automatización de procesos y soluciones RPA para empresas en Chile y Argentina.",
-    avatar: daniloToroImg,
+    avatar: gabrielToroImg,
     socials: [
       {
         name: socialIcons.linkedin.name,

--- a/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
+++ b/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
@@ -1,7 +1,7 @@
 import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
-import thumbnail from "@/public/blog/que-es-rpa/header.jpeg";
+import thumbnail from "@/public/blog/rpa-con-peras-y-manzanas/header.jpeg";
 import ButtonMain from "@/components/ButtonMain.js";
 
 // Tailwind class helpers tailored for this post.
@@ -109,7 +109,7 @@ export const post = {
   publishedAt: "2026-05-13",
   image: {
     src: thumbnail,
-    urlRelative: "/blog/que-es-rpa/header.jpeg",
+    urlRelative: "/blog/rpa-con-peras-y-manzanas/header.jpeg",
     alt: "RPA con peras y manzanas",
   },
   content: (


### PR DESCRIPTION
## Resumen

Apunta el post "RPA con Peras y Manzanas" a su banner propio en
`public/blog/rpa-con-peras-y-manzanas/header.jpeg` en lugar de
reutilizar el de `que-es-rpa`.

## ⚠️ Importante antes de mergear

Este PR **requiere** que el archivo `header.jpeg` esté presente en
`public/blog/rpa-con-peras-y-manzanas/` o el build de Vercel va a
fallar (el `import` resuelve el archivo en tiempo de build).

Pasos:
1. Agregar `public/blog/rpa-con-peras-y-manzanas/header.jpeg` al branch
   `claude/rpa-peras-banner`.
2. Commit + push.
3. Verificar que la preview de Vercel buildea OK.
4. Mergear.

## Test plan

- [ ] Vercel preview compila sin error.
- [ ] `/es/blog` muestra la card del post con el nuevo banner.
- [ ] OG image (compartir el link) usa la imagen nueva.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Poambb4fK61bAT5WLABGkR)_