### PR TITLE
Mejora SEO: H1 con keywords, schemas y casos en desarrollo-software/roi-calculator

### DIFF
--- a/app/[locale]/desarrollo-software/layout.js
+++ b/app/[locale]/desarrollo-software/layout.js
@@ -2,10 +2,10 @@ import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
 
 export const metadata = getSEOTags({
-  title: `Desarrollo de Software a medida para Empresas | ${config.appName}`,
-  description: "Somos tu socio tecnológico. Nos encargamos de desarrollar la tecnología que necesitas desde la estrategia hasta la implementación.",
+  title: `Desarrollo de Software a Medida para Empresas | ${config.appName}`,
+  description: "Desarrollo de software a medida, sistemas web y apps móviles para empresas en Latinoamérica. Integramos RPA, IA y APIs con tus sistemas legacy. Casos reales, equipo certificado y ROI medible.",
   canonicalUrlRelative: "/desarrollo-software",
-}); 
+});
 
 export default function Layout({ children }) {
   return <>{children}</>;

--- a/app/[locale]/desarrollo-software/page.js
+++ b/app/[locale]/desarrollo-software/page.js
@@ -6,9 +6,14 @@ import SoftwareHero from "@/components/SoftwareHero";
 import SoftwareAdvantages from "@/components/SoftwareAdvantages";
 import SoftwareMethodology from "@/components/SoftwareMethodology";
 import SoftwareTechStack from "@/components/SoftwareTechStack";
+import SoftwareSuccessStories from "@/components/SoftwareSuccessStories";
 import SoftwareCTA from "@/components/SoftwareCTA";
 import SoftwareFAQ from "@/components/SoftwareFAQ";
+import TestimonialsSection from "@/components/TestimonialsSection";
 import { getSEOTags } from "@/libs/seo";
+import config from "@/config";
+
+const siteOrigin = `https://www.${config.domainName.replace(/^www\./, "")}`;
 
 export async function generateMetadata({ params }) {
   const { locale } = await params;
@@ -24,7 +29,83 @@ export async function generateMetadata({ params }) {
   });
 }
 
-const DesarrolloSoftwarePage = () => {
+const buildJsonLd = (locale) => {
+  const pageUrl = `${siteOrigin}/${locale}/desarrollo-software`;
+  const service = {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    name: "Desarrollo de Software a Medida",
+    serviceType: "Custom Software Development",
+    provider: {
+      "@type": "Organization",
+      name: "Robotipy",
+      url: siteOrigin,
+    },
+    areaServed: ["Chile", "Argentina", "Perú", "México", "Colombia", "España"],
+    description:
+      "Desarrollo de software a medida, sistemas web, apps móviles e integraciones con RPA e IA para empresas en Latinoamérica.",
+    url: pageUrl,
+  };
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Inicio", item: `${siteOrigin}/${locale}` },
+      { "@type": "ListItem", position: 2, name: "Desarrollo de Software", item: pageUrl },
+    ],
+  };
+  const faq = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "¿Cuánto cuesta desarrollar un software a medida o un bot RPA?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "El costo depende del alcance. Desarrollamos desde scripts de automatización RPA hasta sistemas empresariales complejos. Tras una fase de descubrimiento gratuita entregamos un presupuesto detallado y un cálculo del ROI estimado.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "¿Es seguro integrar robots con nuestros sistemas bancarios o ERP?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Sí. Nuestras soluciones interactúan de forma segura (encriptación TLS, manejo de credenciales) con sistemas como SAP, Salesforce o portales bancarios, sin comprometer la integridad ni el compliance.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "¿Quién es propietario del código fuente y la propiedad intelectual?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "El cliente. Entregamos la propiedad completa del código fuente y los derechos intelectuales del software o bots que construimos al finalizar el proyecto.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "¿Brindan servicios fuera de Chile?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Sí. Trabajamos de forma remota con empresas en Chile, Argentina, Perú, México, Colombia y España, adaptándonos a tu zona horaria.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "¿Pueden integrar el nuevo software con nuestros sistemas legacy?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Sí. Diseñamos APIs y conectores RPA para que tu software moderno se comunique con infraestructura antigua o herramientas de terceros.",
+        },
+      },
+    ],
+  };
+  return [service, breadcrumb, faq];
+};
+
+const DesarrolloSoftwarePage = async ({ params }) => {
+  const { locale } = await params;
+  const jsonLdBlocks = buildJsonLd(locale);
   return (
     <>
       <Suspense>
@@ -33,12 +114,21 @@ const DesarrolloSoftwarePage = () => {
       <main id="main-content">
         <SoftwareHero />
         <SoftwareAdvantages />
+        <SoftwareSuccessStories />
+        <TestimonialsSection />
         <SoftwareMethodology />
         <SoftwareTechStack />
         <SoftwareCTA />
         <SoftwareFAQ />
       </main>
       <Footer />
+      {jsonLdBlocks.map((block, idx) => (
+        <script
+          key={idx}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(block) }}
+        />
+      ))}
     </>
   );
 };

--- a/app/[locale]/roi-calculator/layout.js
+++ b/app/[locale]/roi-calculator/layout.js
@@ -1,12 +1,91 @@
+import { getTranslations } from "next-intl/server";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
 
-export const metadata = getSEOTags({
-  title: `Calculadora de ROI para RPA | ${config.appName}`,
-  description: "Calcula el ROI de tu proyecto de automatización con nuestra calculadora de ROI para RPA. Conoce cuánto podrías ahorrar con la automatización de tus procesos.",
-  canonicalUrlRelative: "/desarrollo-software",
-}); 
+const siteOrigin = `https://www.${config.domainName.replace(/^www\./, "")}`;
 
-export default function Layout({ children }) {
-  return <>{children}</>;
-} 
+export async function generateMetadata({ params }) {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "seo.pages.roiCalculator",
+  });
+  return getSEOTags({
+    locale,
+    title: t("title"),
+    description: t("description"),
+    canonicalUrlRelative: "/roi-calculator",
+  });
+}
+
+const buildJsonLd = (locale) => {
+  const pageUrl = `${siteOrigin}/${locale}/roi-calculator`;
+  const webApp = {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    name: "Calculadora ROI RPA",
+    url: pageUrl,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    description:
+      "Calculadora gratuita para estimar el ROI, payback y VPN de un proyecto de automatización RPA con licencias Rocketbot.",
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    provider: { "@type": "Organization", name: "Robotipy", url: siteOrigin },
+  };
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Inicio", item: `${siteOrigin}/${locale}` },
+      { "@type": "ListItem", position: 2, name: "Calculadora ROI RPA", item: pageUrl },
+    ],
+  };
+  const faq = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "¿Cómo se calcula el ROI de un proyecto RPA?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "El ROI de RPA se calcula comparando los beneficios anuales (ahorro de horas, reducción de errores, eliminación de horas extra, multas y pérdidas evitadas) contra la inversión total (licencias, desarrollo y mantenimiento), aplicando un descuento del 10% para obtener el Valor Presente Neto a tres años.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "¿Qué payback típico tiene una automatización RPA?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "La mayoría de procesos repetitivos que automatizamos con Rocketbot recuperan la inversión entre 4 y 12 meses, dependiendo del volumen, costo del personal y complejidad del proceso.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "¿Qué costos incluye una implementación RPA?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Licencias del software RPA (Rocketbot u otro), desarrollo del robot (en promedio USD 5.800 por bot), infraestructura de orquestación y mantenimiento anual (aprox. 10% del desarrollo).",
+        },
+      },
+    ],
+  };
+  return [webApp, breadcrumb, faq];
+};
+
+export default async function Layout({ children, params }) {
+  const { locale } = await params;
+  const jsonLdBlocks = buildJsonLd(locale);
+  return (
+    <>
+      {children}
+      {jsonLdBlocks.map((block, idx) => (
+        <script
+          key={idx}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(block) }}
+        />
+      ))}
+    </>
+  );
+}

--- a/app/[locale]/roi-calculator/page.js
+++ b/app/[locale]/roi-calculator/page.js
@@ -440,12 +440,30 @@ Detalles del proceso:
           <div className="max-w-7xl mx-auto text-white">
             <div className="text-center mb-12">
               <h1 className="text-4xl lg:text-6xl font-bold tracking-tight mb-6">
-                Calculadora de ROI
+                Calculadora ROI RPA
               </h1>
               <p className="text-lg lg:text-xl text-cyan-300 max-w-3xl mx-auto">
-                Calcula el retorno de inversión para tu proyecto de automatización. 
-                Configura tus parámetros y ve resultados instantáneos.
+                Calcula el retorno de inversión de tu proyecto de automatización RPA. Estima
+                ahorros anuales, periodo de recuperación (payback) y Valor Presente Neto a 3
+                años con licencias Rocketbot, desarrollo y mantenimiento.
               </p>
+              <div className="max-w-3xl mx-auto mt-6 text-left text-cyan-200 text-sm lg:text-base space-y-3">
+                <h2 className="text-xl lg:text-2xl font-semibold text-cyan-50 text-center">
+                  ¿Cómo funciona la calculadora ROI para automatización RPA?
+                </h2>
+                <p>
+                  La calculadora ROI RPA suma los beneficios anuales (horas liberadas,
+                  reducción de errores, horas extra evitadas, multas y pérdidas
+                  recuperadas) y los compara contra la inversión total: licencias RPA,
+                  desarrollo del robot y mantenimiento. Aplicamos un descuento del 10%
+                  para obtener el VPN a 3 años, la misma metodología que usan los
+                  equipos financieros al evaluar proyectos de tecnología.
+                </p>
+                <p>
+                  Úsala para construir un caso de negocio sólido antes de presentar un
+                  proyecto de automatización al comité de inversión o a finanzas.
+                </p>
+              </div>
               <div className="m-4">
                 <button
                   onClick={() => setShowDemoModal(true)}

--- a/libs/seo.js
+++ b/libs/seo.js
@@ -90,6 +90,19 @@ export const getSEOTags = ({
       creator: "@robotipy",
     },
 
+    // Explicit indexing directives to avoid Search Console warnings about missing meta robots.
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        "max-image-preview": "large",
+        "max-snippet": -1,
+        "max-video-preview": -1,
+      },
+    },
+
     // If a canonical URL is given, we add it (locale-prefixed) plus hreflang alternates.
     ...(canonicalUrlRelative && {
       alternates: buildAlternates(activeLocale, canonicalUrlRelative),

--- a/messages/en.json
+++ b/messages/en.json
@@ -62,8 +62,8 @@
     "mobileMenuLabel": "Site navigation"
   },
   "hero": {
-    "title": "We build the <strong>intelligence</strong> that<br></br> your <strong>business</strong> needs.",
-    "subtitle": "Optimize your processes with our automation, <br></br><strong>artificial intelligence and software development solutions.</strong>",
+    "title": "<strong>RPA Automation</strong>, AI and<br></br> <strong>Custom Software</strong>",
+    "subtitle": "Optimize your processes with our RPA automation, <br></br><strong>artificial intelligence and custom software development solutions.</strong>",
     "contactButton": "Contact us",
     "projectsButton": "See our projects"
   },
@@ -371,8 +371,8 @@
     "cta": "Request Training"
   },
   "softwareHero": {
-    "title": "We build the technology <br></br>your business needs to win",
-    "subtitle": "We design and develop robust, scalable and secure web, mobile and enterprise systems tailored to your unique business goals.",
+    "title": "Custom Software Development<br></br>for Enterprises in Latin America",
+    "subtitle": "We design and build custom software, web systems, mobile apps and enterprise platforms that integrate with your stack and accelerate operations.",
     "cta": "Quote your Project"
   },
   "productShared": {
@@ -753,8 +753,12 @@
         "description": "Empower your team with our hands-on courses and advanced specializations in RPA and AI. Training for business and technical teams."
       },
       "desarrolloSoftware": {
-        "title": "Custom Software Development | Robotipy",
-        "description": "We build the technology your business needs to win. Robust, scalable and secure software development tailored to your unique goals."
+        "title": "Custom Software Development for Enterprises | Robotipy",
+        "description": "Custom software development, web systems and mobile apps for companies across Latin America. We integrate RPA, AI and APIs with your legacy systems. Real cases, certified team and measurable ROI."
+      },
+      "roiCalculator": {
+        "title": "RPA ROI Calculator: Estimate Your Automation Returns | Robotipy",
+        "description": "Free RPA ROI calculator. Estimate savings, payback period and NPV for your automation project including Rocketbot licenses, development and maintenance. Instant results."
       }
     }
   }

--- a/messages/en.json
+++ b/messages/en.json
@@ -62,8 +62,8 @@
     "mobileMenuLabel": "Site navigation"
   },
   "hero": {
-    "title": "<strong>RPA Automation</strong>, AI and<br></br> <strong>Custom Software</strong>",
-    "subtitle": "Optimize your processes with our RPA automation, <br></br><strong>artificial intelligence and custom software development solutions.</strong>",
+    "title": "We build the <strong>intelligence</strong> that<br></br> your <strong>business</strong> needs.",
+    "subtitle": "Optimize your processes with our automation, <br></br><strong>artificial intelligence and software development solutions.</strong>",
     "contactButton": "Contact us",
     "projectsButton": "See our projects"
   },
@@ -733,8 +733,8 @@
     "defaultDescriptionShort": "Process automation (RPA), AI Chatbots and custom software development. Professional solutions to optimize processes and reduce business costs.",
     "pages": {
       "home": {
-        "title": "Robotipy - RPA Automation, AI Chatbots and Software",
-        "description": "Process automation (RPA), AI Chatbots and custom software development. Professional solutions to optimize processes and reduce costs."
+        "title": "RPA Automation, AI and Custom Software | Robotipy",
+        "description": "RPA automation with Rocketbot, AI agents and custom software development for enterprises in Latin America. Cut costs, errors and cycle times with measurable ROI."
       },
       "rpa": {
         "title": "RPA with Rocketbot - Process Automation | Robotipy",

--- a/messages/es.json
+++ b/messages/es.json
@@ -62,8 +62,8 @@
     "mobileMenuLabel": "Navegación del sitio"
   },
   "hero": {
-    "title": "<strong>Automatización RPA</strong>, IA y<br></br> <strong>Software a Medida</strong>",
-    "subtitle": "Optimiza tus procesos con nuestras soluciones de automatización RPA, <br></br><strong>inteligencia artificial y desarrollo de software a medida.</strong>",
+    "title": "Creamos la <strong>inteligencia</strong> que<br></br> tu <strong>negocio</strong> necesita.",
+    "subtitle": "Optimiza tus procesos con nuestras soluciones de automatización <br></br><strong>inteligencia artificial y desarrollo de software.</strong>",
     "contactButton": "Contáctanos",
     "projectsButton": "Ve nuestros proyectos"
   },
@@ -733,8 +733,8 @@
     "defaultDescriptionShort": "Automatización de procesos (RPA), Chatbots con IA y desarrollo de software a medida. Soluciones profesionales para optimizar procesos y reducir costos empresariales.",
     "pages": {
       "home": {
-        "title": "Robotipy - Automatización RPA, Chatbots IA y Software",
-        "description": "Automatización de procesos (RPA), Chatbots con IA y desarrollo de software a medida. Soluciones profesionales para optimizar procesos y reducir costos."
+        "title": "Automatización RPA, IA y Software a Medida | Robotipy",
+        "description": "Automatización RPA con Rocketbot, agentes de IA y desarrollo de software a medida para empresas en Latinoamérica. Reduce costos, errores y tiempos con ROI medible."
       },
       "rpa": {
         "title": "RPA con Rocketbot - Automatización de Procesos | Robotipy",

--- a/messages/es.json
+++ b/messages/es.json
@@ -62,8 +62,8 @@
     "mobileMenuLabel": "Navegación del sitio"
   },
   "hero": {
-    "title": "Creamos la <strong>inteligencia</strong> que<br></br> tu <strong>negocio</strong> necesita.",
-    "subtitle": "Optimiza tus procesos con nuestras soluciones de automatización <br></br><strong>inteligencia artificial y desarrollo de software.</strong>",
+    "title": "<strong>Automatización RPA</strong>, IA y<br></br> <strong>Software a Medida</strong>",
+    "subtitle": "Optimiza tus procesos con nuestras soluciones de automatización RPA, <br></br><strong>inteligencia artificial y desarrollo de software a medida.</strong>",
     "contactButton": "Contáctanos",
     "projectsButton": "Ve nuestros proyectos"
   },
@@ -371,8 +371,8 @@
     "cta": "Solicitar Capacitación"
   },
   "softwareHero": {
-    "title": "Construimos la Tecnología que <br></br>tu negocio necesita para ganar",
-    "subtitle": "Diseñamos y desarrollamos sistemas web, móviles y empresariales robustos, escalables y seguros que se adaptan a tus objetivos comerciales únicos.",
+    "title": "Desarrollo de Software a Medida<br></br>para Empresas en Latinoamérica",
+    "subtitle": "Diseñamos y desarrollamos software a medida, sistemas web, apps móviles y plataformas empresariales que se integran con tu stack actual y aceleran tu operación.",
     "cta": "Cotizar tu Proyecto"
   },
   "productShared": {
@@ -753,8 +753,12 @@
         "description": "Potencia a tu equipo con nuestros cursos prácticos y especializaciones avanzadas en RPA e IA. Capacitación para equipos empresariales y técnicos."
       },
       "desarrolloSoftware": {
-        "title": "Desarrollo de Software Personalizado | Robotipy",
-        "description": "Construimos la tecnología que tu negocio necesita para ganar. Desarrollo de software robusto, escalable y seguro adaptado a tus objetivos únicos."
+        "title": "Desarrollo de Software a Medida para Empresas | Robotipy",
+        "description": "Desarrollo de software a medida, sistemas web y apps móviles para empresas en Latinoamérica. Integramos RPA, IA y APIs con tus sistemas legacy. Casos reales, equipo certificado y ROI medible."
+      },
+      "roiCalculator": {
+        "title": "Calculadora ROI RPA: Calcula el Retorno de la Automatización | Robotipy",
+        "description": "Calculadora ROI RPA gratuita. Estima ahorros, payback y VPN de tu proyecto de automatización con licencias Rocketbot, desarrollo y mantenimiento. Resultados instantáneos."
       }
     }
   }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -62,8 +62,8 @@
     "mobileMenuLabel": "Navegação do site"
   },
   "hero": {
-    "title": "<strong>Automação RPA</strong>, IA e<br></br> <strong>Software Sob Medida</strong>",
-    "subtitle": "Otimize seus processos com nossas soluções de automação RPA, <br></br><strong>inteligência artificial e desenvolvimento de software sob medida.</strong>",
+    "title": "Criamos a <strong>inteligência</strong> que<br></br> seu <strong>negócio</strong> precisa.",
+    "subtitle": "Otimize seus processos com nossas soluções de automação, <br></br><strong>inteligência artificial e desenvolvimento de software.</strong>",
     "contactButton": "Fale conosco",
     "projectsButton": "Veja nossos projetos"
   },
@@ -733,8 +733,8 @@
     "defaultDescriptionShort": "Automação de processos (RPA), Chatbots com IA e desenvolvimento de software sob medida. Soluções profissionais para otimizar processos e reduzir custos.",
     "pages": {
       "home": {
-        "title": "Robotipy - Automação RPA, Chatbots IA e Software",
-        "description": "Automação de processos (RPA), Chatbots com IA e desenvolvimento de software sob medida. Soluções profissionais para otimizar processos e reduzir custos."
+        "title": "Automação RPA, IA e Software Sob Medida | Robotipy",
+        "description": "Automação RPA com Rocketbot, agentes de IA e desenvolvimento de software sob medida para empresas na América Latina. Reduza custos, erros e tempos com ROI mensurável."
       },
       "rpa": {
         "title": "RPA com Rocketbot - Automação de Processos | Robotipy",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -62,8 +62,8 @@
     "mobileMenuLabel": "Navegação do site"
   },
   "hero": {
-    "title": "Criamos a <strong>inteligência</strong> que<br></br> seu <strong>negócio</strong> precisa.",
-    "subtitle": "Otimize seus processos com nossas soluções de automação, <br></br><strong>inteligência artificial e desenvolvimento de software.</strong>",
+    "title": "<strong>Automação RPA</strong>, IA e<br></br> <strong>Software Sob Medida</strong>",
+    "subtitle": "Otimize seus processos com nossas soluções de automação RPA, <br></br><strong>inteligência artificial e desenvolvimento de software sob medida.</strong>",
     "contactButton": "Fale conosco",
     "projectsButton": "Veja nossos projetos"
   },
@@ -371,8 +371,8 @@
     "cta": "Solicitar Capacitação"
   },
   "softwareHero": {
-    "title": "Construímos a tecnologia <br></br>que seu negócio precisa para vencer",
-    "subtitle": "Projetamos e desenvolvemos sistemas web, móveis e empresariais robustos, escaláveis e seguros, adaptados aos seus objetivos únicos.",
+    "title": "Desenvolvimento de Software Sob Medida<br></br>para Empresas na América Latina",
+    "subtitle": "Projetamos e desenvolvemos software sob medida, sistemas web, apps móveis e plataformas empresariais que se integram ao seu stack e aceleram a operação.",
     "cta": "Cotar seu Projeto"
   },
   "productShared": {
@@ -753,8 +753,12 @@
         "description": "Capacite sua equipe com nossos cursos práticos e especializações avançadas em RPA e IA. Treinamento para equipes empresariais e técnicas."
       },
       "desarrolloSoftware": {
-        "title": "Desenvolvimento de Software Personalizado | Robotipy",
-        "description": "Construímos a tecnologia que seu negócio precisa para vencer. Desenvolvimento de software robusto, escalável e seguro adaptado aos seus objetivos únicos."
+        "title": "Desenvolvimento de Software Sob Medida para Empresas | Robotipy",
+        "description": "Desenvolvimento de software sob medida, sistemas web e apps móveis para empresas na América Latina. Integramos RPA, IA e APIs com seus sistemas legacy. Casos reais, equipe certificada e ROI mensurável."
+      },
+      "roiCalculator": {
+        "title": "Calculadora ROI RPA: Calcule o Retorno da Automação | Robotipy",
+        "description": "Calculadora ROI RPA gratuita. Estime economias, payback e VPL do seu projeto de automação com licenças Rocketbot, desenvolvimento e manutenção. Resultados instantâneos."
       }
     }
   }


### PR DESCRIPTION
## Resumen

Atiende las falencias SEO del informe estratégico y los WARN de la auditoría técnica.

### Cambios por página

**Home `/es` (H1 genérico → keywords)**
- Hero H1 en `es`, `en`, `pt` ahora arranca con las keywords objetivo: "Automatización RPA, IA y Software a Medida" (equivalente en EN/PT).
- Subtitle reforzado con "RPA" y "software a medida".

**`/desarrollo-software` (posición 18.2, CTR 0.4%)**
- Title: "Desarrollo de Software a Medida para Empresas | Robotipy".
- Meta description reescrita con keywords (software a medida, sistemas web, apps móviles, RPA, IA, APIs, legacy, Latinoamérica).
- H1 del `SoftwareHero` reescrito: "Desarrollo de Software a Medida para Empresas en Latinoamérica".
- Se agregan **casos de éxito** (`SoftwareSuccessStories`) y **testimonios** (`TestimonialsSection`) al flujo de la página.
- JSON-LD: `Service` + `BreadcrumbList` + `FAQPage` (basado en las FAQs ya existentes).

**`/roi-calculator` (posición 26.3, sin ranking para "calculadora ROI RPA")**
- Fix: el canonical apuntaba a `/desarrollo-software`, ahora apunta a `/roi-calculator`.
- Title: "Calculadora ROI RPA: Calcula el Retorno de la Automatización | Robotipy".
- Meta description optimizada para "calculadora ROI RPA".
- H1: "Calculadora ROI RPA" + bloque H2 "¿Cómo funciona la calculadora ROI para automatización RPA?" con contenido explicativo sobre metodología (VPN, payback, descuento 10%) para mejorar dwell time y relevancia semántica.
- JSON-LD: `WebApplication` + `BreadcrumbList` + `FAQPage`.

### WARN de auditoría técnica resueltos

- **Meta Robots**: `libs/seo.js` ahora emite `robots: { index: true, follow: true, googleBot: {...} }` para todas las páginas.
- **Structured Data**: se suman `Service`, `WebApplication`, `BreadcrumbList` y `FAQPage` además del `Corporation` ya presente en el root layout.
- **Hreflang**: `getSEOTags` ya construía `alternates.languages` cuando se pasa `canonicalUrlRelative`. El fix en `/roi-calculator` (que no tenía canonical propio) destraba la emisión de hreflang en esa ruta.

## Test plan

- [ ] Navegar `/es`, `/en`, `/pt` y verificar el nuevo H1 del hero.
- [ ] Verificar que `/es/desarrollo-software` muestra casos y testimonios.
- [ ] Verificar que `/es/roi-calculator` muestra el nuevo H1 + bloque explicativo y que `view-source` contiene el JSON-LD de `WebApplication`, `BreadcrumbList` y `FAQPage`.
- [ ] Revisar en DevTools que el `<meta name="robots" content="index, follow, ...">` aparece en todas las páginas.
- [ ] Validar los schemas con https://search.google.com/test/rich-results.
- [ ] Confirmar `<link rel="alternate" hreflang="es-ES|en-US|pt-BR|x-default">` en `/desarrollo-software` y `/roi-calculator`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CE5BsCgxG4AWwZEJCMZAvb)_