### PR TITLE
SEO: FAQPage schema en post RPA, cluster temático y regla en CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,32 @@ artículos. Resumen de lo no negociable:
 - Estilos compartidos de contenido: `app/[locale]/blog/_assets/styles.js`.
 - Página dinámica: `app/[locale]/blog/[articleId]/page.js`.
 - Cada post exporta `{ slug, locale, title, description, categories,
-  author, publishedAt, image, content }`.
+  author, publishedAt, image, content }`. Si el post incluye una
+  sección de FAQ, también debe exportar `faq: faqs` (ver siguiente
+  sección).
+
+## SEO: FAQs y Schema markup
+
+Cuando agregues o modifiques una sección de Preguntas Frecuentes
+(en posts del blog o en páginas de servicio), siempre:
+
+- Definir las FAQs en un único array `const faqs = [{ q, a }, ...]`,
+  nunca duplicar el contenido entre el render y el schema.
+- En posts del blog, exportar `faq: faqs` en el objeto `post`. La
+  página dinámica `app/[locale]/blog/[articleId]/page.js` emite
+  automáticamente el JSON-LD `FAQPage` cuando el post lo trae.
+- En páginas de servicio (no blog), emitir el `FAQPage` JSON-LD
+  manualmente en `layout.js` o `page.js`, usando el mismo array que
+  renderiza el componente de UI.
+- El texto del schema debe ser idéntico al texto visible (Google
+  penaliza divergencias).
+- Validar con https://search.google.com/test/rich-results antes de
+  mergear.
 
 ## Antes de cerrar una tarea
 
 - Repasar el checklist final de `CONTENT_GUIDELINES.md`.
 - Verificar que no se introdujeron em-dashes ni emojis-viñeta.
 - Confirmar que el post está registrado en `content.js`.
+- Si el post o la página tiene FAQs, confirmar que el `FAQPage`
+  JSON-LD esté presente y sincronizado con el contenido visible.

--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -111,6 +111,27 @@ export default async function Article({ params }) {
         }}
       />
 
+      {Array.isArray(article.faq) && article.faq.length > 0 && (
+        <Script
+          type="application/ld+json"
+          id={`json-ld-faq-${article.slug}`}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "FAQPage",
+              mainEntity: article.faq.map((item) => ({
+                "@type": "Question",
+                name: item.q,
+                acceptedAnswer: {
+                  "@type": "Answer",
+                  text: item.a,
+                },
+              })),
+            }),
+          }}
+        />
+      )}
+
       {/* GO BACK LINK */}
       <div className="max-w-6xl mx-auto">
         <Link

--- a/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
+++ b/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
@@ -1,8 +1,36 @@
+import Link from "next/link";
 import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/rpa-con-peras-y-manzanas/header.jpeg";
 import ButtonMain from "@/components/ButtonMain.js";
+
+const faqs = [
+  {
+    q: "¿El bot RPA puede \"romperse\" si cambia el sistema?",
+    a: "Sí, si cambia la interfaz del sistema que el bot usa (por ejemplo, el SII actualiza su sitio web), puede ser necesario ajustar el bot. Por eso el mantenimiento y soporte son parte fundamental del servicio. En Robotipy, este tipo de ajustes se resuelven rápidamente y forman parte del contrato de soporte.",
+  },
+  {
+    q: "¿Necesito saber programar para usar RPA?",
+    a: "No. Las plataformas modernas como Rocketbot permiten diseñar bots de forma visual, sin escribir código. Tu equipo puede aprender a monitorear y operar los bots con una capacitación básica. El desarrollo técnico lo hace el equipo de Robotipy.",
+  },
+  {
+    q: "¿El bot tiene acceso a información confidencial de mi empresa?",
+    a: "El bot accede solo a los sistemas y datos que tú le das acceso, bajo las mismas credenciales y permisos que defines. Puede implementarse en tu infraestructura local (on-premise) si tienes requerimientos de seguridad estrictos, sin necesidad de exponer datos a la nube.",
+  },
+  {
+    q: "¿RPA reemplaza empleados?",
+    a: "Esta es la pregunta más sensible y la respuesta real es: no reemplaza, libera. La experiencia de nuestros clientes es que las personas que hacían esas tareas repetitivas pasan a enfocarse en trabajo de mayor valor: análisis, atención a clientes, resolución de problemas, estrategia. El bot hace lo mecánico; las personas hacen lo humano.",
+  },
+  {
+    q: "¿Qué pasa si el proceso tiene excepciones o casos especiales?",
+    a: "Los bots pueden manejar múltiples excepciones con reglas condicionales (\"si pasa X, hacer Y; si no, hacer Z\"). Para casos muy inusuales, el bot puede enviar una alerta al equipo humano para que lo resuelva manualmente, y luego continuar con el resto. Ningún proceso es 100% estandarizable, pero RPA cubre el 80–95% de los casos y reduce drásticamente el trabajo manual.",
+  },
+  {
+    q: "¿Funciona con mis sistemas actuales? (SAP, Excel, correo, webs)",
+    a: "Sí. Rocketbot funciona con prácticamente cualquier sistema que tenga interfaz visual: SAP, Oracle, Defontana, Buk, Softland, sistemas web (SII, AFIP, portales bancarios), Excel, Outlook, PDFs, y más. No necesita que los sistemas tengan API.",
+  },
+];
 
 // Tailwind class helpers tailored for this post.
 // Keep the visual structure of the original HTML (callouts, stat cards,
@@ -112,6 +140,7 @@ export const post = {
     urlRelative: "/blog/rpa-con-peras-y-manzanas/header.jpeg",
     alt: "RPA con peras y manzanas",
   },
+  faq: faqs,
   content: (
     <>
       {/* INTRO + STATS */}
@@ -381,7 +410,7 @@ export const post = {
               <tr><td className={ui.td}>Carga de pedidos en ERP</td><td className={ui.td}>Operaciones / Logística</td><td className={ui.td}>Eliminación de carga manual diaria</td><td className={ui.td}><span className={ui.badge("green")}>Fácil</span></td></tr>
               <tr><td className={ui.td}>Envío de reportes automáticos</td><td className={ui.td}>Gerencia / Comercial</td><td className={ui.td}>1–3 horas/semana → automático</td><td className={ui.td}><span className={ui.badge("green")}>Fácil</span></td></tr>
               <tr><td className={ui.td}>Seguimiento de envíos y logística</td><td className={ui.td}>Logística</td><td className={ui.td}>Alertas en tiempo real sin intervención</td><td className={ui.td}><span className={ui.badge("orange")}>Moderado</span></td></tr>
-              <tr><td className={ui.td}>Atención de consultas frecuentes (chatbot)</td><td className={ui.td}>Atención al cliente</td><td className={ui.td}>80% de consultas resueltas sin humano</td><td className={ui.td}><span className={ui.badge("orange")}>Moderado</span></td></tr>
+              <tr><td className={ui.td}>Atención de consultas frecuentes (<Link href="/chatbot" className="link link-accent">chatbot</Link>)</td><td className={ui.td}>Atención al cliente</td><td className={ui.td}>80% de consultas resueltas sin humano</td><td className={ui.td}><span className={ui.badge("orange")}>Moderado</span></td></tr>
               <tr><td className={ui.td}>Procesamiento de solicitudes de seguros</td><td className={ui.td}>Seguros / Salud</td><td className={ui.td}>De días a horas</td><td className={ui.td}><span className={ui.badge("orange")}>Moderado</span></td></tr>
               <tr><td className={ui.td}>Validación de datos entre sistemas</td><td className={ui.td}>TI / Operaciones</td><td className={ui.td}>Eliminación de errores de tipeo</td><td className={ui.td}><span className={ui.badge("green")}>Fácil</span></td></tr>
             </tbody>
@@ -687,14 +716,7 @@ export const post = {
       <section id="faq" className="space-y-3 scroll-mt-24">
         <h2 className={styles.h2}>9. Preguntas Frecuentes sobre RPA</h2>
         <div className="my-6">
-          {[
-            { q: "¿El bot RPA puede \"romperse\" si cambia el sistema?", a: "Sí, si cambia la interfaz del sistema que el bot usa (por ejemplo, el SII actualiza su sitio web), puede ser necesario ajustar el bot. Por eso el mantenimiento y soporte son parte fundamental del servicio. En Robotipy, este tipo de ajustes se resuelven rápidamente y forman parte del contrato de soporte." },
-            { q: "¿Necesito saber programar para usar RPA?", a: "No. Las plataformas modernas como Rocketbot permiten diseñar bots de forma visual, sin escribir código. Tu equipo puede aprender a monitorear y operar los bots con una capacitación básica. El desarrollo técnico lo hace el equipo de Robotipy." },
-            { q: "¿El bot tiene acceso a información confidencial de mi empresa?", a: "El bot accede solo a los sistemas y datos que tú le das acceso, bajo las mismas credenciales y permisos que defines. Puede implementarse en tu infraestructura local (on-premise) si tienes requerimientos de seguridad estrictos, sin necesidad de exponer datos a la nube." },
-            { q: "¿RPA reemplaza empleados?", a: "Esta es la pregunta más sensible y la respuesta real es: no reemplaza, libera. La experiencia de nuestros clientes es que las personas que hacían esas tareas repetitivas pasan a enfocarse en trabajo de mayor valor: análisis, atención a clientes, resolución de problemas, estrategia. El bot hace lo mecánico; las personas hacen lo humano." },
-            { q: "¿Qué pasa si el proceso tiene excepciones o casos especiales?", a: "Los bots pueden manejar múltiples excepciones con reglas condicionales (\"si pasa X, hacer Y; si no, hacer Z\"). Para casos muy inusuales, el bot puede enviar una alerta al equipo humano para que lo resuelva manualmente, y luego continuar con el resto. Ningún proceso es 100% estandarizable, pero RPA cubre el 80–95% de los casos y reduce drásticamente el trabajo manual." },
-            { q: "¿Funciona con mis sistemas actuales? (SAP, Excel, correo, webs)", a: "Sí. Rocketbot funciona con prácticamente cualquier sistema que tenga interfaz visual: SAP, Oracle, Defontana, Buk, Softland, sistemas web (SII, AFIP, portales bancarios), Excel, Outlook, PDFs, y más. No necesita que los sistemas tengan API." },
-          ].map((f, i) => (
+          {faqs.map((f, i) => (
             <details key={i} className={ui.faqItem} open={i === 0}>
               <summary className={ui.faqQ}>
                 <span>{f.q}</span>
@@ -704,6 +726,39 @@ export const post = {
             </details>
           ))}
         </div>
+      </section>
+
+      {/* Cluster temático: links a páginas de servicio */}
+      <section className="space-y-3">
+        <h2 className={styles.h2}>Profundiza en cada servicio</h2>
+        <p className={styles.p}>
+          Si quieres llevar lo que leíste a un proyecto concreto, estas son las páginas donde
+          explicamos cada servicio en detalle:
+        </p>
+        <ul className={styles.ul}>
+          <li className={styles.li}>
+            <Link href="/rpa" className="link link-accent">
+              Automatización RPA con Rocketbot
+            </Link>: cómo construimos bots, qué procesos automatizar primero y nuestra metodología
+            de implementación.
+          </li>
+          <li className={styles.li}>
+            <Link href="/chatbot" className="link link-accent">
+              Chatbots con IA
+            </Link>: asistentes conversacionales conectados a tus datos para atención al cliente y
+            equipos internos.
+          </li>
+          <li className={styles.li}>
+            <Link href="/desarrollo-software" className="link link-accent">
+              Desarrollo de software a medida
+            </Link>: cuando el proceso necesita un sistema propio en vez de (o además de) un bot.
+          </li>
+          <li className={styles.li}>
+            <Link href="/roi-calculator" className="link link-accent">
+              Calculadora ROI RPA
+            </Link>: estima ahorros, payback y VPN antes de presentar el caso de negocio.
+          </li>
+        </ul>
       </section>
 
       {/* CTA */}

--- a/app/[locale]/chatbot/page.js
+++ b/app/[locale]/chatbot/page.js
@@ -4,6 +4,7 @@ import ChatbotProcess from "@/components/ChatbotProcess";
 import ChatbotUseCases from "@/components/ChatbotUseCases";
 import ChatbotFAQ from "@/components/ChatbotFAQ";
 import ChatbotCTA from "@/components/ChatbotCTA";
+import RelatedReading from "@/components/RelatedReading";
 import { Suspense } from "react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -12,6 +13,21 @@ export const metadata = {
   title: "Chatbot Services - Robotipy",
   description: "AI-powered conversational assistants that connect seamlessly to your data sources, providing natural language interface for both internal teams and external clients.",
 };
+
+const chatbotRelatedLinks = [
+  {
+    href: "/blog/rpa-con-peras-y-manzanas",
+    title: "RPA con peras y manzanas: cómo combinar bots y chatbots",
+    description:
+      "Cómo se complementan los chatbots con la automatización RPA para resolver consultas, ejecutar acciones y conectar con tus sistemas.",
+  },
+  {
+    href: "/rpa",
+    title: "Automatización RPA con Rocketbot",
+    description:
+      "Cuando el chatbot necesita ejecutar tareas en SAP, Excel o portales web, RPA es la pieza que completa el flujo.",
+  },
+];
 
 const ChatbotPage = () => {
   return (
@@ -24,6 +40,10 @@ const ChatbotPage = () => {
         <ChatbotFeatures />
         <ChatbotProcess />
         <ChatbotUseCases />
+        <RelatedReading
+          title="Profundiza en automatización conversacional"
+          links={chatbotRelatedLinks}
+        />
         <ChatbotCTA />
         <ChatbotFAQ />
       </main>

--- a/app/[locale]/desarrollo-software/page.js
+++ b/app/[locale]/desarrollo-software/page.js
@@ -10,8 +10,24 @@ import SoftwareSuccessStories from "@/components/SoftwareSuccessStories";
 import SoftwareCTA from "@/components/SoftwareCTA";
 import SoftwareFAQ from "@/components/SoftwareFAQ";
 import TestimonialsSection from "@/components/TestimonialsSection";
+import RelatedReading from "@/components/RelatedReading";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
+
+const softwareRelatedLinks = [
+  {
+    href: "/blog/rpa-con-peras-y-manzanas",
+    title: "RPA con peras y manzanas: cuándo conviene un bot y cuándo un sistema a medida",
+    description:
+      "Guía para decidir si tu proceso necesita un bot RPA, un software propio o ambos integrados.",
+  },
+  {
+    href: "/rpa",
+    title: "Automatización RPA con Rocketbot",
+    description:
+      "Casos donde RPA acelera la automatización antes de invertir en desarrollo de software a medida.",
+  },
+];
 
 const siteOrigin = `https://www.${config.domainName.replace(/^www\./, "")}`;
 
@@ -118,6 +134,10 @@ const DesarrolloSoftwarePage = async ({ params }) => {
         <TestimonialsSection />
         <SoftwareMethodology />
         <SoftwareTechStack />
+        <RelatedReading
+          title="Recursos relacionados"
+          links={softwareRelatedLinks}
+        />
         <SoftwareCTA />
         <SoftwareFAQ />
       </main>

--- a/app/[locale]/rpa/page.js
+++ b/app/[locale]/rpa/page.js
@@ -6,6 +6,22 @@ import Footer from "@/components/Footer";
 import { getSEOTags } from "@/libs/seo";
 import HeroRPA from "./components/HeroRPA";
 import WhatIsRpa from "./components/WhatIsRpa";
+import RelatedReading from "@/components/RelatedReading";
+
+const rpaRelatedLinks = [
+  {
+    href: "/blog/rpa-con-peras-y-manzanas",
+    title: "RPA con peras y manzanas: qué es y cómo funciona",
+    description:
+      "Guía completa con ejemplos por industria, costos reales, ROI esperado y los pasos para implementar RPA en tu empresa.",
+  },
+  {
+    href: "/roi-calculator",
+    title: "Calculadora ROI RPA",
+    description:
+      "Estima ahorros anuales, payback y VPN de tu proyecto de automatización con licencias Rocketbot.",
+  },
+];
 
 export async function generateMetadata({ params }) {
   const { locale } = await params;
@@ -27,6 +43,10 @@ export default function Rpa() {
       <main id="main-content">
         <HeroRPA />
         <WhatIsRpa />
+        <RelatedReading
+          title="Aprende más sobre RPA"
+          links={rpaRelatedLinks}
+        />
         <CTA />
       </main>
       <Footer />

--- a/components/RelatedReading.js
+++ b/components/RelatedReading.js
@@ -1,0 +1,34 @@
+import { Link } from "@/i18n/routing";
+
+const RelatedReading = ({ title, links }) => {
+  if (!links || links.length === 0) return null;
+  return (
+    <section className="py-12 lg:py-16">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-2xl lg:text-3xl font-bold text-white mb-6">
+          {title || "Lectura recomendada"}
+        </h2>
+        <ul className="space-y-4">
+          {links.map((item) => (
+            <li
+              key={item.href}
+              className="border border-white/10 bg-white/5 rounded-xl p-5 hover:border-accent transition-colors"
+            >
+              <Link
+                href={item.href}
+                className="text-accent font-semibold text-lg link link-hover"
+              >
+                {item.title}
+              </Link>
+              <p className="text-white/80 mt-2 text-sm leading-relaxed">
+                {item.description}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default RelatedReading;


### PR DESCRIPTION
## Resumen

Implementa los tres puntos pendientes del informe SEO sobre el post `rpa-con-peras-y-manzanas` y deja la regla escrita para futuros posts.

### 1. Schema FAQPage (sección 9 del post)

- `app/[locale]/blog/[articleId]/page.js`: el renderer del blog ahora emite automáticamente un JSON-LD `FAQPage` cuando el post exporta `faq`. Funciona para cualquier post futuro.
- El post `rpa-con-peras-y-manzanas` define las FAQs en `const faqs = [...]` y las expone como `post.faq`. El render de la sección 9 y el schema usan el mismo array (texto sincronizado, que es lo que valida Google).

### 2. Cluster temático (cross-linking)

- En el cuerpo del post: link inline a `/chatbot` en la tabla de la sección 4, y nueva sección **"Profundiza en cada servicio"** antes del CTA con links a `/rpa`, `/chatbot`, `/desarrollo-software` y `/roi-calculator`.
- Reciprocidad desde las páginas de servicio:
  - `app/[locale]/rpa/page.js` → bloque "Aprende más sobre RPA" linkeando al post y al ROI calculator.
  - `app/[locale]/chatbot/page.js` → bloque "Profundiza en automatización conversacional" linkeando al post y a `/rpa`.
  - `app/[locale]/desarrollo-software/page.js` → bloque "Recursos relacionados" linkeando al post y a `/rpa`.
- `components/RelatedReading.js`: componente compartido reutilizable para esos bloques.

### 3. CLAUDE.md: regla permanente

Nueva sección **"SEO: FAQs y Schema markup"** que obliga a emitir el JSON-LD `FAQPage` siempre que se agreguen o modifiquen FAQs (en posts del blog vía `post.faq`, en páginas de servicio manualmente). Se actualiza también el checklist final y la descripción del shape del post.

### Punto 3 del informe (Search Console)

Es una tarea de monitoreo manual, no de código. Recomiendo agendar revisión en 3-4 semanas filtrando por las URLs `/`, `/desarrollo-software`, `/roi-calculator` y `/blog/rpa-con-peras-y-manzanas`.

## Test plan

- [ ] `view-source` de `/es/blog/rpa-con-peras-y-manzanas` contiene `<script type="application/ld+json" id="json-ld-faq-rpa-con-peras-y-manzanas">` con las 6 preguntas.
- [ ] Validar el schema en https://search.google.com/test/rich-results.
- [ ] Verificar que el post visualmente sigue mostrando las mismas 6 FAQs.
- [ ] Confirmar links en `/es/rpa`, `/es/chatbot` y `/es/desarrollo-software` al post.
- [ ] Confirmar links en el post a `/rpa`, `/chatbot`, `/desarrollo-software`, `/roi-calculator`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CE5BsCgxG4AWwZEJCMZAvb)_