### PR TITLE
Arregla JSON-LD SSR del blog y color de links visitados en post RPA vs IA

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import Script from "next/script";
 import { getArticlesByLocale } from "../_assets/content";
 import BadgeCategory from "../_assets/components/BadgeCategory";
 import Avatar from "../_assets/components/Avatar";
@@ -86,9 +85,8 @@ export default async function Article({ params }) {
   return (
     <>
       {/* SCHEMA JSON-LD MARKUP FOR GOOGLE */}
-      <Script
+      <script
         type="application/ld+json"
-        id={`json-ld-article-${article.slug}`}
         dangerouslySetInnerHTML={{
           __html: JSON.stringify({
             "@context": "https://schema.org",
@@ -112,9 +110,8 @@ export default async function Article({ params }) {
       />
 
       {Array.isArray(article.faq) && article.faq.length > 0 && (
-        <Script
+        <script
           type="application/ld+json"
-          id={`json-ld-faq-${article.slug}`}
           dangerouslySetInnerHTML={{
             __html: JSON.stringify({
               "@context": "https://schema.org",

--- a/app/[locale]/blog/_assets/posts/rpa-vs-ia-agentica.js
+++ b/app/[locale]/blog/_assets/posts/rpa-vs-ia-agentica.js
@@ -857,27 +857,27 @@ export const post = {
         </p>
         <ul className={styles.ul}>
           <li className={styles.li}>
-            <Link href="/rpa" className="link link-accent">
+            <Link href="/rpa" className="text-accent underline hover:text-accent/80 visited:text-accent">
               Automatización RPA con Rocketbot
             </Link>
             : cómo construimos bots, qué procesos automatizar primero y nuestra metodología de
             implementación.
           </li>
           <li className={styles.li}>
-            <Link href="/chatbot" className="link link-accent">
+            <Link href="/chatbot" className="text-accent underline hover:text-accent/80 visited:text-accent">
               Chatbots con IA
             </Link>
             : asistentes conversacionales conectados a tus datos para atención al cliente y equipos
             internos.
           </li>
           <li className={styles.li}>
-            <Link href="/roi-calculator" className="link link-accent">
+            <Link href="/roi-calculator" className="text-accent underline hover:text-accent/80 visited:text-accent">
               Calculadora ROI RPA
             </Link>
             : estima ahorros, payback y VPN antes de presentar el caso de negocio.
           </li>
           <li className={styles.li}>
-            <Link href="/success-cases" className="link link-accent">
+            <Link href="/success-cases" className="text-accent underline hover:text-accent/80 visited:text-accent">
               Casos de éxito
             </Link>
             : 30+ automatizaciones reales, con métricas concretas de ahorro, en industrias de


### PR DESCRIPTION
## Resumen

Dos fixes a partir del feedback en producción del post `rpa-vs-ia-agentica`:

### 1. JSON-LD del blog visible en SSR

`[articleId]/page.js` usaba `<Script>` de `next/script` (con la estrategia por defecto `afterInteractive`) para inyectar los JSON-LD de `Article` y `FAQPage`. Esos scripts se insertan post-hidratación, así que los bots que solo leen el HTML inicial no los veían y la documentación de `CLAUDE.md` (que dice que el `FAQPage` debe emitirse automáticamente cuando el post trae `faq`) no se estaba cumpliendo en la práctica.

**Fix:** reemplazar `<Script>` por `<script>` plano, que es exactamente como ya lo hace `app/[locale]/layout.js` para el `Corporation` schema. Ahora los JSON-LD quedan en el HTML SSR inicial y son crawlables.

### 2. Color de los links en "Profundiza en cada servicio"

Los 4 enlaces internos al final del post (`/rpa`, `/chatbot`, `/roi-calculator`, `/success-cases`) usaban `className="link link-accent"` (DaisyUI). Tras visitarlos, el color caía a un tono oscuro que se confundía con el fondo.

**Fix:** reemplazar por clases Tailwind directas: `text-accent underline hover:text-accent/80 visited:text-accent`. Usa el teal del brand (`rgb(3, 150, 149)` definido en `tailwind.config.js`) en todos los estados (default, hover, visited).

## Pendiente

El usuario reportó un tercer ítem: un `<style id="claude-agent">` que aparece en producción. **No existe en el código fuente** (ningún grep encuentra "claude-agent", "claude_agent" ni similares). Debe estar inyectado por un servicio externo o widget. Pedí al usuario que comparta el HTML del elemento desde dev tools para identificar el origen; cuando me lo pase, abro un PR separado.

## Test plan

- [ ] Abrir `/es/blog/rpa-vs-ia-agentica` y hacer "Ver código fuente" del navegador. Buscar `"@type":"FAQPage"`: debe estar en el HTML inicial (no solo en el DOM hidratado).
- [ ] Validar el JSON-LD con https://search.google.com/test/rich-results.
- [ ] En el post desplegado, hacer clic en uno de los 4 links de "Profundiza en cada servicio", luego volver atrás: el link debe seguir mostrándose en teal claro, no en negro.
- [ ] Confirmar que el resto del blog (otros posts) sigue funcionando.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CE5BsCgxG4AWwZEJCMZAvb)_