### PR TITLE
Incluye posts, categorías y autores del blog en el sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,30 @@
+const fs = require("fs");
+const path = require("path");
+
 const locales = ["es", "en", "pt"];
 const defaultLocale = "es";
 const siteUrl = process.env.SITE_URL || "https://www.robotipy.com";
+
+// Lee los slugs de los posts del blog desde el filesystem.
+// Cada archivo en app/[locale]/blog/_assets/posts/ se llama <slug>.js.
+const postsDir = path.join(__dirname, "app", "[locale]", "blog", "_assets", "posts");
+const blogSlugs = fs
+  .readdirSync(postsDir)
+  .filter((f) => f.endsWith(".js"))
+  .map((f) => f.replace(/\.js$/, ""));
+
+// Slugs de categorias y autores (sincronizados con categories.js y authors.js).
+// Si agregas o quitas categorias/autores, actualiza estas listas.
+const categorySlugs = [
+  "RPA",
+  "Tutoriales",
+  "agtech",
+  "fintech",
+  "logistica",
+  "capacitacion",
+  "casos-de-exito",
+];
+const authorSlugs = ["danilo-toro", "gabriel-toro"];
 
 module.exports = {
   siteUrl,
@@ -17,15 +41,30 @@ module.exports = {
     href: `${siteUrl}/${l}`,
     hreflang: l,
   })),
-  transform: async (config, path) => {
-    const localeMatch = path.match(/^\/([a-z]{2})(\/|$)/);
+  additionalPaths: async (config) => {
+    // Construye entradas para todas las rutas dinamicas del blog en el
+    // locale default. La funcion transform agrega los alternateRefs.
+    const dynamicPaths = [
+      ...blogSlugs.map((slug) => `/${defaultLocale}/blog/${slug}`),
+      ...categorySlugs.map((slug) => `/${defaultLocale}/blog/category/${slug}`),
+      ...authorSlugs.map((slug) => `/${defaultLocale}/blog/author/${slug}`),
+    ];
+    const results = [];
+    for (const p of dynamicPaths) {
+      const entry = await config.transform(config, p);
+      if (entry) results.push(entry);
+    }
+    return results;
+  },
+  transform: async (config, p) => {
+    const localeMatch = p.match(/^\/([a-z]{2})(\/|$)/);
     const pathLocale = localeMatch ? localeMatch[1] : null;
     if (pathLocale && pathLocale !== defaultLocale) {
       return null;
     }
-    const pathWithoutLocale = pathLocale ? path.replace(`/${pathLocale}`, "") || "/" : path;
+    const pathWithoutLocale = pathLocale ? p.replace(`/${pathLocale}`, "") || "/" : p;
     return {
-      loc: path,
+      loc: p,
       changefreq: config.changefreq,
       priority: config.priority,
       lastmod: config.autoLastmod ? new Date().toISOString() : undefined,


### PR DESCRIPTION
## Resumen

El sitemap en producción (`https://www.robotipy.com/sitemap-0.xml`) solo listaba las rutas estáticas: `/es/blog` (índice), las páginas estáticas (`/es/rpa`, `/es/chatbot`, etc.) y los `/es/casos-exito/<industria>`. Faltaban **todas las URLs dinámicas del blog**: los 15 posts individuales, las 7 páginas de categoría y las 2 páginas de autor. Google no estaba descubriendo el contenido más importante del sitio.

### Causa

`next-sitemap` solo enumera rutas estáticas detectables del `.next` build. Las rutas dinámicas como `/blog/[articleId]` requieren configuración explícita vía `additionalPaths`.

### Fix

`next-sitemap.config.js`:

1. Lee los slugs de posts desde el filesystem (`fs.readdirSync('app/[locale]/blog/_assets/posts/')`), ya que el nombre de archivo es el slug.
2. Lista hardcodeada de `categorySlugs` (sincronizada con `categories.js`) y `authorSlugs` (sincronizada con `authors.js`). Si se agregan/quitan, hay que actualizar esta lista, queda un comentario indicándolo.
3. Función `additionalPaths()` que genera entradas para el locale default (`es`) y delega en `transform()` para que añada los `alternateRefs` hreflang de es/en/pt.

### Resultado esperado

El sitemap pasará de ~27 URLs a ~51 URLs (las 27 actuales + 15 posts + 7 categorías + 2 autores).

Verificado localmente:
```
Total dynamic paths: 24
First: /es/blog/capacitacion-rpa-ia
Last: /es/blog/author/gabriel-toro
```

## Test plan

- [ ] Tras mergear y desplegar, abrir `https://www.robotipy.com/sitemap-0.xml`.
- [ ] Verificar que aparecen los 15 posts: `/es/blog/rpa-vs-ia-agentica`, `/es/blog/rpa-con-peras-y-manzanas`, etc.
- [ ] Verificar las 7 categorías: `/es/blog/category/RPA`, `/es/blog/category/casos-de-exito`, etc.
- [ ] Verificar los 2 autores: `/es/blog/author/danilo-toro`, `/es/blog/author/gabriel-toro`.
- [ ] Cada entrada debe tener sus `<xhtml:link hreflang>` para es/en/pt.
- [ ] Resubmitir el sitemap en Google Search Console (`Sitemaps → /sitemap.xml`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CE5BsCgxG4AWwZEJCMZAvb)_