### PR TITLE
Arregla URLs duplicadas en hreflang del sitemap (bug SEO crítico)

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -71,6 +71,9 @@ module.exports = {
       alternateRefs: locales.map((l) => ({
         href: `${config.siteUrl}/${l}${pathWithoutLocale === "/" ? "" : pathWithoutLocale}`,
         hreflang: l,
+        // next-sitemap por defecto concatena `loc` al final de `href`. Como
+        // aqui ya construimos la URL completa, lo deshabilitamos.
+        hrefIsAbsolute: true,
       })),
     };
   },


### PR DESCRIPTION
## Resumen

El sitemap actual emite URLs `hreflang` con el path duplicado, lo que rompe las señales de internacionalización ante Google.

### Antes

```xml
<url>
  <loc>https://www.robotipy.com/es/ai-info</loc>
  ...
  <xhtml:link rel="alternate" hreflang="es"
              href="https://www.robotipy.com/es/ai-info/es/ai-info"/>
  <xhtml:link rel="alternate" hreflang="en"
              href="https://www.robotipy.com/en/ai-info/es/ai-info"/>
  <xhtml:link rel="alternate" hreflang="pt"
              href="https://www.robotipy.com/pt/ai-info/es/ai-info"/>
</url>
```

### Después

```xml
<url>
  <loc>https://www.robotipy.com/es/ai-info</loc>
  ...
  <xhtml:link rel="alternate" hreflang="es" href="https://www.robotipy.com/es/ai-info"/>
  <xhtml:link rel="alternate" hreflang="en" href="https://www.robotipy.com/en/ai-info"/>
  <xhtml:link rel="alternate" hreflang="pt" href="https://www.robotipy.com/pt/ai-info"/>
</url>
```

### Causa

`next-sitemap` v4.2.3, al normalizar las `alternateRefs`, llama internamente a `this.absoluteUrl(...)` sobre cada `href`. Por defecto eso concatena el path del `loc` al final. Nuestro `transform` ya construía la URL completa (`siteUrl + /locale + /path`), así que el path quedaba dos veces.

El bug existía desde antes pero pasaba más desapercibido cuando había pocas URLs. Con la incorporación de los 24 posts/categorías/autores del blog en PR #27 se hizo más visible.

### Fix

Marcar cada `alternateRef` con `hrefIsAbsolute: true`. Esta flag (que sí existe en v4.2.3 según la fuente) le indica a `next-sitemap` que respete la URL tal cual, sin concatenar.

Una sola línea de cambio en `next-sitemap.config.js`.

## Test plan

- [ ] Mergear y desplegar.
- [ ] Abrir `https://www.robotipy.com/sitemap-0.xml` y verificar que ningún `hreflang` muestra el path duplicado.
- [ ] Validar con https://www.xml-sitemaps.com/validate-xml-sitemap.html.
- [ ] Validar hreflang en Google Search Console (sección Internationalization).
- [ ] Resubmitir sitemap en GSC para acelerar el reprocesado.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CE5BsCgxG4AWwZEJCMZAvb)_