### PR TITLE
Corregir menú hamburguesa del blog en mobile

### DIFF
--- a/app/[locale]/blog/_assets/components/HeaderBlog.js
+++ b/app/[locale]/blog/_assets/components/HeaderBlog.js
@@ -217,7 +217,7 @@ const HeaderBlog = () => {
       {/* Mobile menu, show/hide based on menu state. */}
       <div className={`relative z-50 ${isOpen ? "" : "hidden"}`}>
         <div
-          className={`fixed inset-y-0 right-0 z-10 w-full px-8 py-3 overflow-y-auto bg-white sm:max-w-sm sm:ring-1 sm:ring-neutral/10 transform origin-right transition ease-in-out duration-300`}
+          className={`fixed inset-y-0 right-0 z-10 w-full px-8 py-3 overflow-y-auto bg-[#00182B] sm:max-w-sm sm:ring-1 sm:ring-neutral/10 transform origin-right transition ease-in-out duration-300`}
         >
           {/* Your logo/name on small screens */}
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- El panel del menú mobile en el blog usaba `bg-white` como fondo, pero todo el texto interno tenía clase `text-white`, resultando en contenido completamente invisible (blanco sobre blanco)
- Se cambia el fondo a `bg-[#00182B]` (color primario de la marca Robotipy) para que el texto blanco sea legible

## Test plan
- [ ] Abrir cualquier página del blog en viewport mobile (< 1024px)
- [ ] Tocar el icono de hamburguesa y verificar que el menú se despliega con fondo oscuro
- [ ] Verificar que los links ("Todos los Posts", "Categories") son visibles y clicables
- [ ] Verificar que el botón "Contáctanos" se ve correctamente
- [ ] Verificar que el botón de cerrar (X) es visible y funciona

https://claude.ai/code/session_015tDpqE3pV8bkC6qS4t66by

---
_Generated by [Claude Code](https://claude.ai/code/session_015tDpqE3pV8bkC6qS4t66by)_