### PR TITLE
Rediseñar el blog con el sistema estilo magazine de melonhelp

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -1,8 +1,12 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { getArticlesByLocale } from "../_assets/content";
 import BadgeCategory from "../_assets/components/BadgeCategory";
-import Avatar from "../_assets/components/Avatar";
+import ReadingProgress from "../_assets/components/ReadingProgress";
+import ArticleShare from "../_assets/components/ArticleShare";
+import StickyCta from "../_assets/components/StickyCta";
+import logo from "@/app/icon.png";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
 
@@ -14,8 +18,8 @@ export async function generateMetadata({ params }) {
 
   if (!articleId || !Array.isArray(localeArticles)) {
     return getSEOTags({
-      title: "Article Not Found",
-      description: "The requested article could not be found.",
+      title: "Artículo no encontrado",
+      description: "El artículo solicitado no se pudo encontrar.",
     });
   }
 
@@ -23,8 +27,8 @@ export async function generateMetadata({ params }) {
 
   if (!article) {
     return getSEOTags({
-      title: "Article Not Found",
-      description: "The requested article could not be found.",
+      title: "Artículo no encontrado",
+      description: "El artículo solicitado no se pudo encontrar.",
     });
   }
 
@@ -44,12 +48,35 @@ export async function generateMetadata({ params }) {
             height: 660,
           },
         ],
-        locale: "en_US",
-        type: "website",
+        locale: "es_LA",
+        type: "article",
       },
     },
   });
 }
+
+// Enlaces evergreen para que "Sigue leyendo" siempre muestre tres tarjetas,
+// incluso cuando no hay suficientes artículos relacionados.
+const EVERGREEN = [
+  {
+    tag: "Herramienta",
+    title: "Calcula el ROI de automatizar",
+    href: "/roi-calculator",
+    meta: "Calculadora interactiva",
+  },
+  {
+    tag: "Casos de éxito",
+    title: "Casos reales de automatización",
+    href: "/casos-exito",
+    meta: "Resultados medibles",
+  },
+  {
+    tag: "Robotipy",
+    title: "Conoce qué hacemos",
+    href: "/",
+    meta: "RPA, IA y software a medida",
+  },
+];
 
 export default async function Article({ params }) {
   const resolvedParams = await params;
@@ -68,22 +95,41 @@ export default async function Article({ params }) {
   }
 
   const articleCategories = (article.categories || []).filter(Boolean);
+  const category = articleCategories[0];
 
-  const articlesRelated = localeArticles
-    .filter(
-      (a) =>
-        a.slug !== articleId &&
-        a.categories &&
-        Array.isArray(a.categories) &&
-        a.categories.filter(Boolean).some((c) =>
-          articleCategories.map((cat) => cat.slug).includes(c.slug)
-        )
-    )
-    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))
-    .slice(0, 3);
+  const formattedDate = new Date(article.publishedAt).toLocaleDateString(
+    "es-ES",
+    { day: "numeric", month: "long", year: "numeric" }
+  );
+
+  const toCard = (a) => ({
+    tag: a.categories?.find(Boolean)?.titleShort || "Blog",
+    title: a.title,
+    href: `/blog/${a.slug}`,
+    meta: a.readingTime ? `${a.readingTime} min de lectura` : "Artículo",
+  });
+
+  const others = localeArticles
+    .filter((a) => a.slug !== articleId)
+    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+
+  // Primero artículos que comparten categoría, luego cualquier reciente y, por
+  // último, evergreen para que siempre haya tres tarjetas.
+  const sameCategory = others.filter(
+    (a) =>
+      a.categories &&
+      a.categories
+        .filter(Boolean)
+        .some((c) => articleCategories.map((x) => x.slug).includes(c.slug))
+  );
+  const relatedPosts = [
+    ...sameCategory,
+    ...others.filter((a) => !sameCategory.includes(a)),
+  ];
+  const readMore = [...relatedPosts.map(toCard), ...EVERGREEN].slice(0, 3);
 
   return (
-    <>
+    <div className="relative overflow-hidden bg-[#00182B]">
       {/* SCHEMA JSON-LD MARKUP FOR GOOGLE */}
       <script
         type="application/ld+json"
@@ -104,6 +150,14 @@ export default async function Article({ params }) {
             author: {
               "@type": "Person",
               name: article.author.name,
+            },
+            publisher: {
+              "@type": "Organization",
+              name: config.appName,
+              logo: {
+                "@type": "ImageObject",
+                url: `https://${config.domainName}/images/robotipy-logo.png`,
+              },
             },
           }),
         }}
@@ -129,100 +183,166 @@ export default async function Article({ params }) {
         />
       )}
 
-      {/* GO BACK LINK */}
-      <div className="max-w-6xl mx-auto">
-        <Link
-          href="/blog"
-          className="link !no-underline text-white/80 hover:text-white inline-flex items-center gap-1"
-          title="Volver al Blog"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            className="w-5 h-5"
+      <ReadingProgress />
+      <StickyCta />
+
+      <article className="relative mx-auto max-w-[880px] px-6 pt-8">
+        {/* TOP BAR: VOLVER + COMPARTIR */}
+        <div className="mb-12 flex items-center justify-between">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-2.5 text-[14px] text-white/70 transition-colors hover:text-accent"
+            title="Volver al Blog"
           >
-            <path
-              fillRule="evenodd"
-              d="M15 10a.75.75 0 01-.75.75H7.612l2.158 1.96a.75.75 0 11-1.04 1.08l-3.5-3.25a.75.75 0 010-1.08l3.5-3.25a.75.75 0 111.04 1.08L7.612 9.25h6.638A.75.75 0 0115 10z"
-              clipRule="evenodd"
-            />
-          </svg>
-          Volver al Blog
-        </Link>
-      </div>
-
-      <article className="max-w-7xl mx-auto">
-        {/* HEADER WITH CATEGORIES AND DATE AND TITLE */}
-        <section className="my-8 md:my-12">
-          <div className="flex items-center gap-4 mb-6">
-            {articleCategories.map((category) => (
-              <BadgeCategory
-                category={category}
-                key={category.slug}
-                extraStyle="!badge-lg"
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-4 h-4"
+            >
+              <path
+                fillRule="evenodd"
+                d="M15 10a.75.75 0 01-.75.75H7.612l2.158 1.96a.75.75 0 11-1.04 1.08l-3.5-3.25a.75.75 0 010-1.08l3.5-3.25a.75.75 0 111.04 1.08L7.612 9.25h6.638A.75.75 0 0115 10z"
+                clipRule="evenodd"
               />
-            ))}
-            <span className="text-white/80" itemProp="datePublished">
-              {new Date(article.publishedAt).toLocaleDateString("en-US", {
-                month: "long",
-                day: "numeric",
-                year: "numeric",
-              })}
-            </span>
-          </div>
+            </svg>
+            Volver al Blog
+          </Link>
+          <ArticleShare title={article.title} />
+        </div>
 
-          <h1 className="text-white text-4xl md:text-5xl font-extrabold tracking-tight mb-3 md:mb-4">
+        {/* HEADER CENTRADO */}
+        <header className="mx-auto max-w-[700px] text-center">
+          <Image
+            src={logo}
+            alt={config.appName}
+            width={80}
+            height={80}
+            className="mx-auto mb-[22px] h-16 w-16 object-contain"
+            priority
+          />
+          <div className="mb-[22px] inline-flex flex-wrap items-center justify-center gap-3 text-[13px] text-white/60">
+            {category && (
+              <span className="font-display text-[12px] font-bold uppercase tracking-[0.06em] text-accent">
+                {category.titleShort || category.title}
+              </span>
+            )}
+            {article.readingTime && (
+              <>
+                <span className="h-[3px] w-[3px] rounded-full bg-white/30" />
+                <span className="inline-flex items-center gap-1.5">
+                  <svg
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    className="w-[11px] h-[11px]"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  {article.readingTime} min de lectura
+                </span>
+              </>
+            )}
+            <span className="h-[3px] w-[3px] rounded-full bg-white/30" />
+            <span itemProp="datePublished">{formattedDate}</span>
+          </div>
+          <h1 className="mb-[18px] font-display text-[34px] font-extrabold leading-[1.07] tracking-[-0.025em] text-white md:text-[42px]">
             {article.title}
           </h1>
-{/* 
-          <p className="text-white/80 md:text-lg max-w-[700px]">
+          <p className="text-[18px] leading-[1.6] text-white/70">
             {article.description}
-          </p> */}
-        </section>
+          </p>
+        </header>
 
-        <div className="flex flex-col md:flex-row">
-          {/* SIDEBAR WITH AUTHORS AND 3 RELATED ARTICLES */}
-          <section className="basis-2/7 max-md:pb-4 md:pl-3 lg:pl-5 max-md:border-b md:border-l md:order-last md:w-72 shrink-0 border-white/10">
-            <p className="text-white/80 text-sm mb-2 md:mb-3 lg:text-lg">
-              Publicado por
-            </p>
-            <Avatar article={article} />
+        <div className="mx-auto my-10 h-[3px] w-[46px] rounded-sm bg-accent" />
 
-            {articlesRelated.length > 0 && (
-              <div className="hidden md:block mt-12">
-                <p className=" text-white/80 text-lg  mb-2 md:mb-3">
-                  Artículos relacionados
-                </p>
-                <div className="space-y-2 md:space-y-5">
-                  {articlesRelated.map((article) => (
-                    <div className="" key={article.slug}>
-                      <p className="mb-0.5">
-                        <Link
-                          href={`/blog/${article.slug}`}
-                          className="link link-hover link-success font-medium"
-                          title={article.title}
-                          rel="bookmark"
-                        >
-                          {article.title}
-                        </Link>
-                      </p>
-                      <p className="text-white/80 max-w-full text-sm">
-                        {article.description}
-                      </p>
-                    </div>
-                  ))}
-                </div>
+        {/* CUERPO */}
+        <div className="space-y-12">{article.content}</div>
+
+        {/* BIO DEL AUTOR */}
+        <div className="mx-auto mt-12 flex max-w-[700px] items-center gap-4 rounded-2xl border border-white/[0.07] bg-secondary px-7 py-[26px]">
+          <span className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-accent/20">
+            <Image
+              src={article.author.avatar}
+              alt={article.author.name}
+              width={56}
+              height={56}
+              className="h-14 w-14 object-cover object-center"
+            />
+          </span>
+          <div>
+            <div className="mb-0.5 font-display text-[16px] font-bold text-white">
+              {article.author.name}
+            </div>
+            {article.author.job && (
+              <div className="mb-1 text-[13px] font-medium text-accent">
+                {article.author.job}
               </div>
             )}
-          </section>
-
-          {/* ARTICLE CONTENT */}
-          <section className="basis-5/7 w-full max-md:pt-2 md:pr-20 space-y-12">
-            {article.content}
-          </section>
+            <div className="text-[14px] leading-[1.5] text-white/70">
+              {article.author.description}
+            </div>
+          </div>
         </div>
       </article>
-    </>
+
+      {/* BANDA CTA */}
+      <div className="relative mx-auto mt-14 max-w-[880px] px-6">
+        <div className="relative overflow-hidden rounded-[24px] bg-accent px-10 py-12 text-center">
+          <h2 className="relative mb-3 font-display text-[28px] font-extrabold leading-[1.12] tracking-[-0.01em] text-white md:text-[32px]">
+            ¿Listo para automatizar tus procesos?
+          </h2>
+          <p className="relative mb-7 text-[17px] text-white/90">
+            Conversemos sobre tu caso. Te mostramos dónde automatizar y cuánto
+            puedes ahorrar.
+          </p>
+          <Link
+            href="/contact-us"
+            className="relative inline-flex h-[52px] items-center gap-2.5 rounded-xl bg-white px-[30px] font-display text-[17px] font-semibold text-accent transition hover:-translate-y-px"
+          >
+            Agenda una reunión
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-4 h-4"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5 10a.75.75 0 01.75-.75h6.638L10.23 7.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 11-1.04-1.08l2.158-1.96H5.75A.75.75 0 015 10z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </Link>
+        </div>
+      </div>
+
+      {/* SIGUE LEYENDO */}
+      <div className="relative mx-auto max-w-[880px] px-6 pb-[72px] pt-16">
+        <div className="mb-6 font-display text-[22px] font-extrabold text-white">
+          Sigue leyendo
+        </div>
+        <div className="flex flex-wrap gap-5">
+          {readMore.map((card) => (
+            <Link
+              key={card.href}
+              href={card.href}
+              className="block min-w-[210px] flex-1 rounded-2xl border border-white/[0.07] bg-secondary p-6 transition-colors hover:border-accent/40"
+            >
+              <span className="font-display text-[11px] font-bold uppercase tracking-[0.06em] text-accent">
+                {card.tag}
+              </span>
+              <div className="my-3 font-display text-[18px] font-bold leading-[1.3] text-white">
+                {card.title}
+              </div>
+              <div className="text-[13px] text-white/60">{card.meta}</div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/app/[locale]/blog/_assets/components/ArticleShare.js
+++ b/app/[locale]/blog/_assets/components/ArticleShare.js
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+// Fila de compartir: copiar enlace + WhatsApp / X / LinkedIn. SVG inline para no
+// agregar dependencias de iconos.
+const ArticleShare = ({ title }) => {
+  const [copied, setCopied] = useState(false);
+
+  const url = () => (typeof window !== "undefined" ? window.location.href : "");
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      /* clipboard bloqueado: no-op */
+    }
+  };
+
+  const enc = () => encodeURIComponent(url());
+  const encTitle = encodeURIComponent(title);
+
+  const circle =
+    "flex h-[34px] w-[34px] items-center justify-center rounded-full bg-white/10 text-white/80 transition-colors hover:bg-accent hover:text-white";
+
+  return (
+    <div className="flex gap-2.5">
+      <button type="button" onClick={copy} aria-label="Copiar enlace" className={circle}>
+        {copied ? (
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-[15px] h-[15px]">
+            <path
+              fillRule="evenodd"
+              d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+              clipRule="evenodd"
+            />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 20 20" fill="currentColor" className="w-[15px] h-[15px]">
+            <path d="M12.232 4.232a2.5 2.5 0 013.536 3.536l-1.225 1.224a.75.75 0 001.061 1.06l1.224-1.224a4 4 0 00-5.656-5.656l-3 3a4 4 0 00.225 5.865.75.75 0 00.977-1.138 2.5 2.5 0 01-.142-3.667l3-3z" />
+            <path d="M11.603 7.963a.75.75 0 00-.977 1.138 2.5 2.5 0 01.142 3.667l-3 3a2.5 2.5 0 01-3.536-3.536l1.225-1.224a.75.75 0 00-1.061-1.06l-1.224 1.224a4 4 0 105.656 5.656l3-3a4 4 0 00-.225-5.865z" />
+          </svg>
+        )}
+      </button>
+      <a
+        href={`https://wa.me/?text=${encTitle}%20${enc()}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Compartir en WhatsApp"
+        className={circle}
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" className="w-[15px] h-[15px]">
+          <path d="M.057 24l1.687-6.163a11.867 11.867 0 01-1.587-5.946C.16 5.335 5.495 0 12.05 0a11.817 11.817 0 018.413 3.488 11.824 11.824 0 013.48 8.414c-.003 6.557-5.338 11.892-11.893 11.892a11.9 11.9 0 01-5.688-1.448L.057 24zm6.597-3.807c1.676.995 3.276 1.591 5.392 1.592 5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.892-5.452 0-9.887 4.434-9.889 9.884a9.86 9.86 0 001.6 5.366l-.999 3.648 3.889-1.013zm11.387-5.464c-.074-.124-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.462-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.521.149-.174.198-.298.298-.497.099-.198.05-.372-.025-.521-.074-.149-.669-1.611-.916-2.206-.242-.579-.487-.501-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.709.306 1.263.489 1.694.626.712.226 1.36.194 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.695.248-1.29.173-1.414z" />
+        </svg>
+      </a>
+      <a
+        href={`https://twitter.com/intent/tweet?text=${encTitle}&url=${enc()}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Compartir en X"
+        className={circle}
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" className="w-[14px] h-[14px]">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      </a>
+      <a
+        href={`https://www.linkedin.com/sharing/share-offsite/?url=${enc()}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Compartir en LinkedIn"
+        className={circle}
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" className="w-[15px] h-[15px]">
+          <path d="M4.98 3.5c0 1.381-1.11 2.5-2.48 2.5s-2.48-1.119-2.48-2.5c0-1.38 1.11-2.5 2.48-2.5s2.48 1.12 2.48 2.5zm.02 4.5h-5v16h5v-16zm7.982 0h-4.968v16h4.969v-8.399c0-4.67 6.029-5.052 6.029 0v8.399h4.988v-10.131c0-7.88-8.922-7.593-11.018-3.714v-2.155z" />
+        </svg>
+      </a>
+    </div>
+  );
+};
+
+export default ArticleShare;

--- a/app/[locale]/blog/_assets/components/BadgeCategory.js
+++ b/app/[locale]/blog/_assets/components/BadgeCategory.js
@@ -1,14 +1,14 @@
 import Link from "next/link";
 
-// This is the category badge that appears in the article page and in <CardArticle /> component
+// Badge de categoría que aparece en la página del artículo y en <CardArticle />.
 const Category = ({ category, extraStyle }) => {
   return (
     <Link
       href={`/blog/category/${category.slug}`}
-      className={`badge badge-sm md:badge-md hover:badge-primary hover:border-white text-primary bg-white ${
+      className={`inline-flex items-center rounded-full border border-accent/25 bg-accent/15 px-2.5 py-0.5 font-display text-xs font-semibold uppercase tracking-[0.04em] text-accent transition-colors hover:bg-accent hover:text-white ${
         extraStyle ? extraStyle : ""
       }`}
-      title={`Posts in ${category.title}`}
+      title={`Posts en ${category.title}`}
       rel="tag"
     >
       {category.titleShort}

--- a/app/[locale]/blog/_assets/components/CardArticle.js
+++ b/app/[locale]/blog/_assets/components/CardArticle.js
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import Image from "next/image";
 import BadgeCategory from "./BadgeCategory";
-import Avatar from "./Avatar";
 
-// This is the article card that appears in the home page, in the category page, and in the author's page
+// Tarjeta de artículo usada en el índice, en las categorías y en la página de
+// autor. Tema oscuro con borde, coherente con el design system de Robotipy.
 const CardArticle = ({
   article,
   tag = "h2",
@@ -13,15 +13,9 @@ const CardArticle = ({
   const TitleTag = tag;
 
   return (
-    <article className="card bg-white rounded-box overflow-hidden">
+    <article className="flex flex-col overflow-hidden rounded-2xl border border-white/[0.07] bg-secondary transition-colors hover:border-accent/40">
       {article.image?.src && (
-        <Link
-          href={`/blog/${article.slug}`}
-          className="link link-hover hover:link-primary"
-          title={article.title}
-          aria-label={`Read article: ${article.title}`}
-          rel="bookmark"
-        >
+        <Link href={`/blog/${article.slug}`} title={article.title} rel="bookmark">
           <figure>
             <Image
               src={article.image.src}
@@ -30,15 +24,14 @@ const CardArticle = ({
               height={338}
               priority={isImagePriority}
               placeholder="blur"
-              className="aspect-video object-center object-cover hover:scale-[1.03] duration-200 ease-in-out"
+              className="aspect-video object-cover object-center duration-200 ease-in-out hover:scale-[1.03]"
             />
           </figure>
         </Link>
       )}
-      <div className="card-body">
-        {/* CATEGORIES */}
+      <div className="flex flex-1 flex-col p-6">
         {showCategory && article.categories && article.categories.length > 0 && (
-          <div className="flex flex-wrap gap-2">
+          <div className="mb-3 flex flex-wrap gap-2">
             {article.categories
               .filter((category) => category && category.slug)
               .map((category) => (
@@ -47,11 +40,10 @@ const CardArticle = ({
           </div>
         )}
 
-        {/* TITLE WITH RIGHT TAG */}
-        <TitleTag className="mb-1 text-xl md:text-2xl font-bold">
+        <TitleTag className="mb-2 font-display text-[20px] font-bold leading-[1.3] text-white">
           <Link
             href={`/blog/${article.slug}`}
-            className="link link-hover hover:link-primary text-primary"
+            className="hover:text-accent"
             title={article.title}
             rel="bookmark"
           >
@@ -59,21 +51,38 @@ const CardArticle = ({
           </Link>
         </TitleTag>
 
-        <div className=" text-primary space-y-4">
-          {/* DESCRIPTION */}
-          <p className="text-primary">{article.description}</p>
+        <p className="mb-5 text-[15px] leading-[1.6] text-white/70">
+          {article.description}
+        </p>
 
-          {/* AUTHOR & DATE */}
-          <div className="flex items-center gap-4 text-sm">
-            <Avatar article={article} />
-
-            <span itemProp="datePublished">
-              {new Date(article.publishedAt).toLocaleDateString("en-US", {
-                month: "long",
-                day: "numeric",
-              })}
-            </span>
-          </div>
+        <div className="mt-auto flex items-center gap-3 text-[13px] text-white/60">
+          <span>{article.author.name}</span>
+          <span className="h-[3px] w-[3px] rounded-full bg-white/30" />
+          <span itemProp="datePublished">
+            {new Date(article.publishedAt).toLocaleDateString("es-ES", {
+              day: "numeric",
+              month: "long",
+            })}
+          </span>
+          {article.readingTime && (
+            <>
+              <span className="h-[3px] w-[3px] rounded-full bg-white/30" />
+              <span className="inline-flex items-center gap-1.5">
+                <svg
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="w-3 h-3"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                {article.readingTime} min
+              </span>
+            </>
+          )}
         </div>
       </div>
     </article>

--- a/app/[locale]/blog/_assets/components/CardCategory.js
+++ b/app/[locale]/blog/_assets/components/CardCategory.js
@@ -1,17 +1,17 @@
 import Link from "next/link";
 
-// This is the category card that appears in the home page and in the category page
+// Tarjeta de categoría que aparece en el índice y en la página de categoría.
 const CardCategory = ({ category, tag = "h2" }) => {
   const TitleTag = tag;
 
   return (
     <Link
-      className="p-4 bg-base-200 text-base-content rounded-box duration-200 hover:bg-neutral hover:text-neutral-content"
+      className="rounded-xl border border-white/[0.07] bg-secondary p-4 text-white transition-colors duration-200 hover:border-accent/40 hover:text-accent"
       href={`/blog/category/${category.slug}`}
       title={category.title}
       rel="tag"
     >
-      <TitleTag className="md:text-lg font-medium">
+      <TitleTag className="font-display font-semibold md:text-lg">
         {category?.titleShort || category.title}
       </TitleTag>
     </Link>

--- a/app/[locale]/blog/_assets/components/ReadingProgress.js
+++ b/app/[locale]/blog/_assets/components/ReadingProgress.js
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Barra fija de progreso de lectura (relleno accent) en la parte superior.
+const ReadingProgress = () => {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const doc = document.documentElement;
+      const max = doc.scrollHeight - doc.clientHeight || 1;
+      const pct = Math.min(
+        100,
+        Math.max(0, ((doc.scrollTop || window.scrollY) / max) * 100)
+      );
+      setProgress(pct);
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-[60] h-1 bg-white/10">
+      <div
+        className="h-full bg-accent transition-[width] duration-75 ease-linear"
+        style={{ width: `${progress}%` }}
+      />
+    </div>
+  );
+};
+
+export default ReadingProgress;

--- a/app/[locale]/blog/_assets/components/StickyCta.js
+++ b/app/[locale]/blog/_assets/components/StickyCta.js
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+// CTA flotante "Agenda una reunión" que aparece al pasar el header, para que la
+// conversión esté siempre a mano sin volver arriba.
+const StickyCta = () => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () =>
+      setShow((window.scrollY || document.documentElement.scrollTop) > 700);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <Link
+      href="/contact-us"
+      className={`fixed bottom-5 right-5 z-50 inline-flex h-12 items-center gap-2 rounded-xl bg-accent px-5 font-display text-[15px] font-semibold text-white shadow-[0_14px_36px_rgba(0,0,0,0.4)] transition-all duration-300 hover:bg-accent/90 ${
+        show
+          ? "translate-y-0 opacity-100"
+          : "pointer-events-none translate-y-3 opacity-0"
+      }`}
+    >
+      Agenda una reunión
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="w-4 h-4"
+      >
+        <path
+          fillRule="evenodd"
+          d="M5 10a.75.75 0 01.75-.75h6.638L10.23 7.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 11-1.04-1.08l2.158-1.96H5.75A.75.75 0 015 10z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </Link>
+  );
+};
+
+export default StickyCta;

--- a/app/[locale]/blog/author/[authorId]/page.js
+++ b/app/[locale]/blog/author/[authorId]/page.js
@@ -10,8 +10,8 @@ export async function generateMetadata({ params }) {
   const author = authors.find((author) => author.slug === authorId);
 
   return getSEOTags({
-    title: `${author.name}, Author at ${config.appName}'s Blog`,
-    description: `${author.name}, Author at ${config.appName}'s Blog`,
+    title: `${author.name}, autor en el Blog de ${config.appName}`,
+    description: `${author.name}, autor en el Blog de ${config.appName}`,
     canonicalUrlRelative: `/blog/author/${author.slug}`,
   });
 }
@@ -24,41 +24,43 @@ export default async function Author({ params }) {
     .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
 
   return (
-    <>
-      <section className="max-w-3xl mx-auto flex flex-col md:flex-row gap-8 mt-12 mb-24 md:mb-32">
+    <div className="mx-auto max-w-[1140px] px-6 py-16">
+      <section className="mx-auto mb-16 flex max-w-3xl flex-col gap-8 md:mb-24 md:flex-row md:items-center">
         <div>
-          <p className="text-xs uppercase tracking-wide text-base-content/80 mb-2">
-            Authors
-          </p>
-          <h1 className="font-extrabold text-3xl lg:text-5xl tracking-tight mb-2">
+          <div className="mb-4 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
+            Autor
+          </div>
+          <h1 className="mb-2 font-display text-[clamp(32px,4.5vw,50px)] font-extrabold leading-[1.05] tracking-[-0.02em] text-white">
             {author.name}
           </h1>
-          <p className="md:text-lg mb-6 md:mb-10 font-medium">{author.job}</p>
-          <p className="md:text-lg text-base-content/80">
+          <p className="mb-6 font-display text-[18px] font-medium text-accent">
+            {author.job}
+          </p>
+          <p className="text-[18px] leading-[1.6] text-white/70">
             {author.description}
           </p>
         </div>
 
-        <div className="max-md:order-first flex md:flex-col gap-4 shrink-0">
+        <div className="flex shrink-0 gap-4 max-md:order-first md:flex-col md:items-center">
           <Image
             src={author.avatar}
             width={256}
             height={256}
             alt={author.name}
             priority={true}
-            className="rounded-box w-[12rem] md:w-[16rem] "
+            className="w-[12rem] rounded-2xl md:w-[16rem]"
           />
 
           {author.socials?.length > 0 && (
-            <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex gap-3">
               {author.socials.map((social) => (
                 <a
                   key={social.name}
                   href={social.url}
-                  className="btn btn-square"
-                  // Using a dark theme? -> className="btn btn-square btn-neutral"
-                  title={`Go to ${author.name} profile on ${social.name}`}
+                  className="flex h-11 w-11 items-center justify-center rounded-full border border-white/[0.07] bg-secondary text-white transition-colors hover:border-accent/40 hover:text-accent [&_svg]:h-5 [&_svg]:w-5 [&_svg]:fill-current"
+                  title={`Ir al perfil de ${author.name} en ${social.name}`}
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   {social.icon}
                 </a>
@@ -69,16 +71,16 @@ export default async function Author({ params }) {
       </section>
 
       <section>
-        <h2 className="font-bold text-2xl lg:text-4xl tracking-tight text-center mb-8 md:mb-12">
-          Most recent articles by {author.name}
+        <h2 className="mb-8 text-center font-display text-2xl font-extrabold text-white md:mb-12 lg:text-3xl">
+          Artículos recientes de {author.name}
         </h2>
 
-        <div className="grid lg:grid-cols-2 gap-8">
+        <div className="grid gap-6 lg:grid-cols-2">
           {articlesByAuthor.map((article) => (
             <CardArticle key={article.slug} article={article} />
           ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/app/[locale]/blog/category/[categoryId]/page.js
+++ b/app/[locale]/blog/category/[categoryId]/page.js
@@ -10,7 +10,7 @@ export async function generateMetadata({ params }) {
   const category = categories.find((category) => category.slug === categoryId);
 
   return getSEOTags({
-    title: `${category.title} | Blog by ${config.appName}`,
+    title: `${category.title} | Blog de ${config.appName}`,
     description: category.description,
     canonicalUrlRelative: `/blog/category/${category.slug}`,
   });
@@ -23,26 +23,28 @@ export default async function Category({ params }) {
     .filter((article) =>
       article.categories.map((c) => c.slug).includes(category.slug)
     )
-    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt))
-    .slice(0, 3);
+    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
 
   return (
-    <>
-      <section className="mt-12 mb-24 md:mb-32 max-w-3xl mx-auto text-center">
-        <h1 className="font-extrabold text-3xl lg:text-5xl tracking-tight mb-6 md:mb-12">
+    <div className="mx-auto max-w-[1140px] px-6 py-16">
+      <section className="mx-auto mb-16 max-w-3xl text-center md:mb-24">
+        <div className="mb-4 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
+          Categoría
+        </div>
+        <h1 className="mb-5 font-display text-[clamp(32px,4.5vw,50px)] font-extrabold leading-[1.05] tracking-[-0.02em] text-white">
           {category.title}
         </h1>
-        <p className="md:text-lg opacity-80 max-w-xl mx-auto">
+        <p className="text-[18px] leading-[1.6] text-white/70">
           {category.description}
         </p>
       </section>
 
-      <section className="mb-24">
-        <h2 className="font-bold text-2xl lg:text-4xl tracking-tight text-center mb-8 md:mb-12">
-          Most recent articles in {category.title}
+      <section className="mb-20 md:mb-28">
+        <h2 className="mb-8 text-center font-display text-2xl font-extrabold text-white md:mb-12 lg:text-3xl">
+          Artículos recientes en {category.title}
         </h2>
 
-        <div className="grid lg:grid-cols-2 gap-8">
+        <div className="grid gap-6 lg:grid-cols-2">
           {articlesInCategory.map((article) => (
             <CardArticle
               key={article.slug}
@@ -55,11 +57,11 @@ export default async function Category({ params }) {
       </section>
 
       <section>
-        <h2 className="font-bold text-2xl lg:text-4xl tracking-tight text-center mb-8 md:mb-12">
-          Other categories you might like
+        <h2 className="mb-8 text-center font-display text-2xl font-extrabold text-white md:mb-12 lg:text-3xl">
+          Otras categorías que te pueden interesar
         </h2>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
           {categories
             .filter((c) => c.slug !== category.slug)
             .map((category) => (
@@ -67,6 +69,6 @@ export default async function Category({ params }) {
             ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/app/[locale]/blog/layout.js
+++ b/app/[locale]/blog/layout.js
@@ -4,14 +4,12 @@ import Footer from "@/components/Footer";
 
 export default async function LayoutBlog({ children }) {
   return (
-    <div>
+    <div className="min-h-screen bg-[#00182B] font-display text-white">
       <Suspense>
         <HeaderBlog />
       </Suspense>
 
-      <main className="min-h-screen mx-auto p-8">{children}</main>
-
-      <div className="h-24" />
+      <main className="min-h-screen">{children}</main>
 
       <Footer />
     </div>

--- a/app/[locale]/blog/page.js
+++ b/app/[locale]/blog/page.js
@@ -6,7 +6,7 @@ import config from "@/config";
 import { getSEOTags } from "@/libs/seo";
 
 export const metadata = getSEOTags({
-  title: `${config.appName} Blog | Automatización de Procesos, Inteligencia Artificial y Desarrollo de Software`,
+  title: `Blog de ${config.appName} | Automatización de Procesos, Inteligencia Artificial y Desarrollo de Software`,
   description:
     "Descubre cómo optimizar y automatizar los procesos de tu empresa para maximizar la eficiencia y construir soluciones que impulsen tu crecimiento empresarial",
   canonicalUrlRelative: "/blog",
@@ -14,20 +14,34 @@ export const metadata = getSEOTags({
 
 export default async function Blog({ params }) {
   const { locale } = await params;
-  const articlesToDisplay = getArticlesByLocale(locale)
-    .sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+  const articlesToDisplay = getArticlesByLocale(locale).sort(
+    (a, b) => new Date(b.publishedAt) - new Date(a.publishedAt)
+  );
+
+  // Solo mostramos categorías que tienen artículos publicados en este locale.
+  const usedCategories = categories.filter((c) =>
+    articlesToDisplay.some((a) =>
+      (a.categories || []).some((ac) => ac && ac.slug === c.slug)
+    )
+  );
+
   return (
-    <>
-      <section className="text-center max-w-2xl md:max-w-4xl lg:max-w-5xl mx-auto mt-12 mb-24 md:mb-32">
-        <h1 className="text-white text-3xl lg:text-5xl tracking-tight mb-6">
-          The {config.appName} Blog
+    <div className="mx-auto max-w-[1140px] px-6 py-16">
+      <section className="mx-auto mb-16 max-w-3xl text-center md:mb-24">
+        <div className="mb-4 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
+          Blog
+        </div>
+        <h1 className="mb-5 font-display text-[clamp(32px,4.5vw,50px)] font-extrabold leading-[1.05] tracking-[-0.02em] text-white">
+          El Blog de {config.appName}
         </h1>
-        <p className="text-white text-lg opacity-80 leading-relaxed">
-            Descubre cómo optimizar y automatizar los procesos de tu empresa para maximizar la eficiencia y construir soluciones que impulsen tu crecimiento empresarial
+        <p className="text-[18px] leading-[1.6] text-white/70">
+          Descubre cómo optimizar y automatizar los procesos de tu empresa para
+          maximizar la eficiencia y construir soluciones que impulsen tu
+          crecimiento empresarial.
         </p>
       </section>
 
-      <section className="grid lg:grid-cols-2 mb-24 md:mb-32 gap-8 max-w-2xl md:max-w-4xl lg:max-w-5xl mx-auto">
+      <section className="mb-20 grid gap-6 md:mb-28 lg:grid-cols-2">
         {articlesToDisplay.map((article, i) => (
           <CardArticle
             article={article}
@@ -38,16 +52,15 @@ export default async function Blog({ params }) {
       </section>
 
       <section>
-        <p className="font-bold text-2xl lg:text-4xl tracking-tight text-center mb-8 md:mb-12 text-white">
+        <h2 className="mb-8 text-center font-display text-2xl font-extrabold text-white md:mb-12 lg:text-3xl">
           Explora los artículos por categoría
-        </p>
-
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {categories.map((category) => (
+        </h2>
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+          {usedCategories.map((category) => (
             <CardCategory key={category.slug} category={category} tag="div" />
           ))}
         </div>
       </section>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Qué

Porta el sistema de blog de **melonhelp** a Robotipy, manteniendo intacto el design system de Robotipy: acento teal (`accent`), fondo `#00182B`, superficies `secondary`, tipografía Inter (`font-display`). Sin colores nuevos y **sin dependencias nuevas** (los iconos de melonhelp en `lucide-react` / `react-icons` se reemplazaron por SVG inline).

## Por qué

El blog usaba el layout clásico del boilerplate (sidebar + tarjetas claras). melonhelp evolucionó a una lectura tipo revista, más inmersiva y con más puntos de conversión. Esta PR trae ese diseño adaptado a Robotipy.

## Cambios

**Página de artículo (`[articleId]/page.js`)**
- Layout centrado (`max-w-880`) en lugar del sidebar.
- Barra de progreso de lectura fija (`ReadingProgress`).
- Fila de compartir: copiar enlace + WhatsApp / X / LinkedIn (`ArticleShare`, SVG inline).
- CTA flotante hacia `/contact-us` (`StickyCta`).
- Header centrado con logo, meta (categoría · tiempo de lectura · fecha) y divisor accent.
- Tarjeta de bio del autor (nombre, cargo, descripción).
- Banda CTA ("¿Listo para automatizar tus procesos?") hacia `/contact-us`.
- "Sigue leyendo" con artículos relacionados y *fallbacks* evergreen (Calculadora ROI, Casos de éxito, Home) para que siempre haya 3 tarjetas.
- Se conserva el JSON-LD `Article` (ahora con `publisher`) y `FAQPage`.

**Componentes compartidos**
- `CardArticle`, `CardCategory`: tarjetas oscuras con borde y hover accent.
- `BadgeCategory`: pill accent.
- Tiempo de lectura opcional (solo se renderiza si el post lo trae) y fechas en `es-ES`.

**Índice / categoría / autor**
- Eyebrow + heading display, contenedores propios y textos en español coherentes.

**Layout**
- Fondo y tipografía del blog unificados.

## Compatibilidad

- Se mantiene el enrutado `[locale]`, JavaScript, `getArticlesByLocale` y los patrones de `Link` existentes.
- `next build` pasa completo (rutas `/[locale]/blog` SSG para es/en/pt; artículo/categoría/autor dinámicas, igual que antes).

## Notas

- El acento de marca (`accent`, teal) sustituye al verde `melon` de melonhelp.
- El CTA apunta a `/contact-us` ("Agenda una reunión") en vez del trial SaaS de melonhelp, acorde al modelo de servicios de Robotipy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_