### PR TITLE
Quitar banda CTA por defecto del blog y arreglar CTAs de "evaluar" sin link

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -290,37 +290,6 @@ export default async function Article({ params }) {
         </div>
       </article>
 
-      {/* BANDA CTA */}
-      <div className="relative mx-auto mt-14 max-w-[880px] px-6">
-        <div className="relative overflow-hidden rounded-[24px] bg-accent px-10 py-12 text-center">
-          <h2 className="relative mb-3 font-display text-[28px] font-extrabold leading-[1.12] tracking-[-0.01em] text-white md:text-[32px]">
-            ¿Listo para automatizar tus procesos?
-          </h2>
-          <p className="relative mb-7 text-[17px] text-white/90">
-            Conversemos sobre tu caso. Te mostramos dónde automatizar y cuánto
-            puedes ahorrar.
-          </p>
-          <Link
-            href="/contact-us"
-            className="relative inline-flex h-[52px] items-center gap-2.5 rounded-xl bg-white px-[30px] font-display text-[17px] font-semibold text-accent transition hover:-translate-y-px"
-          >
-            Agenda una reunión
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="w-4 h-4"
-            >
-              <path
-                fillRule="evenodd"
-                d="M5 10a.75.75 0 01.75-.75h6.638L10.23 7.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 11-1.04-1.08l2.158-1.96H5.75A.75.75 0 015 10z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </Link>
-        </div>
-      </div>
-
       {/* SIGUE LEYENDO */}
       <div className="relative mx-auto max-w-[880px] px-6 pb-[72px] pt-16">
         <div className="mb-6 font-display text-[22px] font-extrabold text-white">

--- a/app/[locale]/blog/_assets/posts/que-procesos-de-sap-se-pueden-automatizar-con-rpa.js
+++ b/app/[locale]/blog/_assets/posts/que-procesos-de-sap-se-pueden-automatizar-con-rpa.js
@@ -359,7 +359,7 @@ export const post = {
           API o una mezcla de las dos.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <ButtonMain href="/contact-us" text="Evaluar mi proceso de SAP" />
+          <ButtonMain link="/contact-us" text="Evaluar mi proceso de SAP" />
           <Link
             href="/blog/como-calcular-el-roi-en-proyectos-rpa"
             className="inline-block px-7 py-3 rounded-full border border-white/30 text-white font-semibold hover:border-white/60 transition-colors"

--- a/app/[locale]/blog/_assets/posts/rpa-vs-ia-agentica.js
+++ b/app/[locale]/blog/_assets/posts/rpa-vs-ia-agentica.js
@@ -886,7 +886,7 @@ export const post = {
         <p className={styles.p}>
           Este framework no es teórico: es exactamente lo que usamos en Robotipy cuando un cliente
           nos contacta. Le hacemos estas 5 preguntas en la{" "}
-          <IntLink href="/#contacto">primera reunión de diagnóstico</IntLink>{" "}
+          <IntLink href="/contact-us">primera reunión de diagnóstico</IntLink>{" "}
           y con las respuestas ya sabemos qué tecnología (o combinación) recomendarle. El 70% de los
           proyectos que implementamos hoy terminan usando algún grado de modelo híbrido, porque la
           realidad de las empresas rara vez cabe en una sola categoría.
@@ -970,7 +970,7 @@ export const post = {
           venderte algo que no necesitas.
         </p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <ButtonMain href="/contact-us" text="Agenda tu evaluación gratuita" />
+          <ButtonMain link="/contact-us" text="Agenda tu evaluación gratuita" />
           <Link
             href="/roi-calculator"
             className="inline-block px-7 py-3 rounded-full border border-white/30 text-white font-semibold hover:border-white/60 transition-colors"


### PR DESCRIPTION
## Qué

Dos arreglos pedidos sobre el blog:

### 1. Quitar la banda CTA por defecto del artículo
La banda teal "¿Listo para automatizar tus procesos? · Agenda una reunión" estaba en la plantilla de todos los artículos (`[articleId]/page.js`) y duplicaba el CTA propio que ya trae cada post. Se elimina del template.

### 2. Arreglar los CTA de "evaluar/diagnóstico" sin enlace válido
`ButtonMain` navega por la prop **`link`**; si no la recibe, renderiza un `<button>` sin navegación. Varios CTA pasaban `href` por error, así que quedaban como botones muertos:

- `que-procesos-de-sap-se-pueden-automatizar-con-rpa.js`: "Evaluar mi proceso de SAP" → `href` cambiado a `link="/contact-us"`.
- `rpa-vs-ia-agentica.js`: "Agenda tu evaluación gratuita" → `href` cambiado a `link="/contact-us"`.
- `rpa-vs-ia-agentica.js`: "primera reunión de diagnóstico" apuntaba a `/#contacto` (ancla que no existe en el home); se reapunta a `/contact-us`.

Revisé los 4 posts más recientes; los otros dos (`rpa-con-peras-y-manzanas`, `caso-exito-rpa-ia-mineria-costos`) ya usaban `link` correctamente. Un grep global confirma que no quedan más `ButtonMain ... href=` ni `/#contacto`.

## Verificación
- `next build` pasa completo.
- Runtime (servidor de producción local):
  - La banda por defecto ya no aparece en el artículo.
  - "Evaluar mi proceso de SAP" y "Agenda tu evaluación gratuita" renderizan como `<a href="/contact-us">` (antes eran `<button>` sin destino).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_