### PR TITLE
Cierre de post: autor antes de un CTA único contextual (template para todo el blog)

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -6,6 +6,7 @@ import BadgeCategory from "../_assets/components/BadgeCategory";
 import ReadingProgress from "../_assets/components/ReadingProgress";
 import ArticleShare from "../_assets/components/ArticleShare";
 import StickyCta from "../_assets/components/StickyCta";
+import ArticleCta from "../_assets/components/ArticleCta";
 import logo from "@/app/icon.png";
 import { getSEOTags } from "@/libs/seo";
 import config from "@/config";
@@ -77,6 +78,17 @@ const EVERGREEN = [
     meta: "RPA, IA y software a medida",
   },
 ];
+
+// CTA de cierre por defecto (tuteo neutro) para posts que no definen el suyo.
+const DEFAULT_CTA = {
+  titulo: "¿Quieres automatizar procesos como este?",
+  texto:
+    "Cuéntanos tu caso y te decimos por dónde empezar, sin compromiso.",
+  botonLabel: "Agenda una reunión",
+  botonUrl: "/contact-us",
+  linkLabel: "Calcula tu ROI",
+  linkUrl: "/roi-calculator",
+};
 
 export default async function Article({ params }) {
   const resolvedParams = await params;
@@ -261,9 +273,35 @@ export default async function Article({ params }) {
 
         {/* CUERPO */}
         <div className="space-y-12">{article.content}</div>
+      </article>
 
-        {/* BIO DEL AUTOR */}
-        <div className="mx-auto mt-12 flex max-w-[700px] items-center gap-4 rounded-2xl border border-white/[0.07] bg-secondary px-7 py-[26px]">
+      {/* SIGUE LEYENDO */}
+      <div className="relative mx-auto max-w-[880px] px-6 pt-16">
+        <div className="mb-6 font-display text-[22px] font-extrabold text-white">
+          Sigue leyendo
+        </div>
+        <div className="flex flex-wrap gap-5">
+          {readMore.map((card) => (
+            <Link
+              key={card.href}
+              href={card.href}
+              className="block min-w-[210px] flex-1 rounded-2xl border border-white/[0.07] bg-secondary p-6 transition-colors hover:border-accent/40"
+            >
+              <span className="font-display text-[11px] font-bold uppercase tracking-[0.06em] text-accent">
+                {card.tag}
+              </span>
+              <div className="my-3 font-display text-[18px] font-bold leading-[1.3] text-white">
+                {card.title}
+              </div>
+              <div className="text-[13px] text-white/60">{card.meta}</div>
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {/* BIO DEL AUTOR (confianza antes del CTA) */}
+      <div className="mx-auto max-w-[880px] px-6 pt-12">
+        <div className="mx-auto flex max-w-[700px] items-center gap-4 rounded-2xl border border-white/[0.07] bg-secondary px-7 py-[26px]">
           <span className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-accent/20">
             <Image
               src={article.author.avatar}
@@ -288,30 +326,11 @@ export default async function Article({ params }) {
             </div>
           </div>
         </div>
-      </article>
+      </div>
 
-      {/* SIGUE LEYENDO */}
-      <div className="relative mx-auto max-w-[880px] px-6 pb-[72px] pt-16">
-        <div className="mb-6 font-display text-[22px] font-extrabold text-white">
-          Sigue leyendo
-        </div>
-        <div className="flex flex-wrap gap-5">
-          {readMore.map((card) => (
-            <Link
-              key={card.href}
-              href={card.href}
-              className="block min-w-[210px] flex-1 rounded-2xl border border-white/[0.07] bg-secondary p-6 transition-colors hover:border-accent/40"
-            >
-              <span className="font-display text-[11px] font-bold uppercase tracking-[0.06em] text-accent">
-                {card.tag}
-              </span>
-              <div className="my-3 font-display text-[18px] font-bold leading-[1.3] text-white">
-                {card.title}
-              </div>
-              <div className="text-[13px] text-white/60">{card.meta}</div>
-            </Link>
-          ))}
-        </div>
+      {/* CTA DE CIERRE ÚNICO Y CONTEXTUAL */}
+      <div className="mx-auto max-w-[880px] px-6 pb-[72px]">
+        <ArticleCta {...(article.cta || DEFAULT_CTA)} />
       </div>
     </div>
   );

--- a/app/[locale]/blog/_assets/components/ArticleCta.js
+++ b/app/[locale]/blog/_assets/components/ArticleCta.js
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import ButtonMain from "@/components/ButtonMain";
+
+// Caja de cierre única y contextual del post. Paleta de marca Robotipy:
+// tarjeta navy (#2D3648) con acento teal. Un botón principal de conversión y un
+// link de texto secundario (no dos botones que compiten).
+const ArticleCta = ({ titulo, texto, botonLabel, botonUrl, linkLabel, linkUrl }) => (
+  <div className="mx-auto mt-12 max-w-[700px] rounded-2xl border border-accent/30 bg-[#2D3648] px-8 py-10 text-center">
+    <h2 className="mb-3 font-display text-[26px] md:text-[30px] font-extrabold leading-[1.15] tracking-tight text-white">
+      {titulo}
+    </h2>
+    {texto && (
+      <p className="mx-auto mb-7 max-w-[540px] text-[16px] leading-[1.6] text-white/80">
+        {texto}
+      </p>
+    )}
+    <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+      <ButtonMain link={botonUrl} text={botonLabel} type="primary" rounded noblank />
+      {linkLabel && linkUrl && (
+        <Link
+          href={linkUrl}
+          className="text-[15px] font-semibold text-accent underline-offset-4 hover:underline"
+        >
+          {linkLabel}
+        </Link>
+      )}
+    </div>
+  </div>
+);
+
+export default ArticleCta;

--- a/app/[locale]/blog/_assets/posts/capacitacion-rpa-ia.js
+++ b/app/[locale]/blog/_assets/posts/capacitacion-rpa-ia.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/capacitacion-rpa-ia/header.jpeg"; // TODO: Replace
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "capacitacion-rpa-ia",
@@ -21,6 +20,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/capacitacion-rpa-ia/header.jpeg", // TODO: Update
     alt: "Capacitacion RPA IA",
+  },
+  cta: {
+    titulo: "¿Quieres que tu equipo tome el control de la automatización?",
+    texto: "Transferimos el conocimiento para que escales con un Centro de Excelencia propio.",
+    botonLabel: "Conoce nuestros programas",
+    botonUrl: "/capacitaciones",
+    linkLabel: "Habla con nosotros",
+    linkUrl: "/contact-us",
   },
   content: (
     <>
@@ -74,9 +81,6 @@ export const post = {
         <p className={styles.p}>
           En Robotipy, no solo implementamos soluciones; transferimos conocimiento. Nuestros programas de capacitación están diseñados para que tu equipo tome el control.
         </p>
-        <div className="flex justify-center mt-5 py-5">
-          <ButtonMain text="Conoce nuestros programas de capacitación" link="/capacitaciones" noblank={true} />
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-financiera-agroindustria.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-financiera-agroindustria.js
@@ -2,7 +2,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/caso-exito-automatizacion-financiera-agroindustria/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-automatizacion-financiera-agroindustria",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/caso-exito-automatizacion-financiera-agroindustria/header.jpeg",
     alt: "Automatización financiera agroindustria Chile RPA",
+  },
+  cta: {
+    titulo: "¿Tu agroindustria pierde horas en tareas financieras?",
+    texto: "Te mostramos qué procesos automatizar primero y cuánto puedes ahorrar.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -95,9 +102,6 @@ export const post = {
         <p className={styles.p}>
           Escalar automatizaciones a múltiples unidades de negocio requiere planificación. <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a> te ayuda a gestionar recursos, timelines y clientes en un solo lugar.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="¿Quieres algo similar? Contáctanos" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-ordenes-sap-siderurgia.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-ordenes-sap-siderurgia.js
@@ -2,7 +2,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/caso-exito-automatizacion-ordenes-sap-siderurgia/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-automatizacion-ordenes-sap-siderurgia",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/caso-exito-automatizacion-ordenes-sap-siderurgia/header.jpeg",
     alt: "Automatización RPA SAP siderurgia Chile",
+  },
+  cta: {
+    titulo: "¿Tienes sistemas que no se hablan entre sí?",
+    texto: "Evaluamos si RPA puede conectarlos en semanas, sin tocar las APIs de ninguno.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -106,9 +113,6 @@ export const post = {
         <p className={styles.p}>
           Proyectos con integraciones complejas como este requieren visibilidad total del avance. Conoce <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a> para gestionar este tipo de iniciativas de forma profesional.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="¿Quieres algo similar? Contáctanos" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-cartolas-factoring-vitivinicola.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-cartolas-factoring-vitivinicola.js
@@ -2,7 +2,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/caso-exito-cartolas-factoring-vitivinicola/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-cartolas-factoring-vitivinicola",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/caso-exito-cartolas-factoring-vitivinicola/header.jpeg",
     alt: "Automatización cartolas factoring vitivinícola Chile",
+  },
+  cta: {
+    titulo: "¿El factoring te consume tiempo administrativo?",
+    texto: "Te decimos si conviene automatizar tu proceso de cesión y cómo hacerlo.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -86,12 +93,6 @@ export const post = {
         <p className={`${styles.p} font-semibold text-cyan-400`}>
           Cada día de retraso en una cesión tiene costo financiero real.
         </p>
-      </section>
-
-      <section className="space-y-3">
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="¿Quieres algo similar? Contáctanos" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-conciliacion-bancaria-agropecuario.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-conciliacion-bancaria-agropecuario.js
@@ -2,7 +2,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/caso-exito-conciliacion-bancaria-agropecuario/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-conciliacion-bancaria-agropecuario",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/caso-exito-conciliacion-bancaria-agropecuario/header.jpeg",
     alt: "Conciliación bancaria automatizada agropecuario Argentina",
+  },
+  cta: {
+    titulo: "¿Tu conciliación bancaria toma días?",
+    texto: "Te mostramos cómo un robot la deja lista para revisar solo las excepciones.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -101,9 +108,6 @@ export const post = {
         <p className={styles.p}>
           Coordinar proyectos multi-entidad como este es más fácil con las herramientas correctas. Descubre <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a> para gestionar tus proyectos de automatización.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="¿Quieres algo similar? Contáctanos" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-inteligencia-mercado-agronegocios.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-inteligencia-mercado-agronegocios.js
@@ -1,7 +1,6 @@
 import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-inteligencia-mercado-agronegocios",
@@ -19,6 +18,14 @@ export const post = {
     src: null,
     urlRelative: "/blog/caso-exito-inteligencia-mercado-agronegocios/header.jpeg",
     alt: "Automatización inteligencia de mercado agronegocios Argentina",
+  },
+  cta: {
+    titulo: "¿Necesitas inteligencia de mercado sin un equipo grande?",
+    texto: "Evaluamos cómo un bot puede darte los datos para decidir en cada reunión.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -97,12 +104,6 @@ export const post = {
         <p className={`${styles.p} font-semibold text-cyan-400`}>
           El bot no reemplazó al analista, le dio la materia prima para que haga su trabajo real: pensar.
         </p>
-      </section>
-
-      <section className="space-y-3">
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="¿Quieres algo similar? Contáctanos" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-logistica.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-logistica.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/caso-exito-logistica/header.jpeg"
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-logistica",
@@ -21,6 +20,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/caso-exito-logistica/header.jpeg", 
     alt: "Caso Exito Logistica RPA",
+  },
+  cta: {
+    titulo: "¿Tu operación logística no escala sin sumar personal?",
+    texto: "Te mostramos qué automatizar para crecer sin contratar más en temporada alta.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -78,11 +85,8 @@ export const post = {
           La automatización no solo redujo costos, sino que habilitó la escalabilidad necesaria para afrontar eventos de alta demanda sin contratar personal temporal excesivo.
         </p>
         <p className={styles.p}>
-          Orquestar múltiples bots requiere gestión profesional de proyectos. Conoce <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a> — diseñado para consultoras que gestionan automatizaciones en producción.
+          Orquestar múltiples bots requiere gestión profesional de proyectos. Conoce <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a>, diseñado para consultoras que gestionan automatizaciones en producción.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="Ver más Casos de Éxito" link="/casos-exito" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/caso-exito-rpa-ia-mineria-costos.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-rpa-ia-mineria-costos.js
@@ -2,7 +2,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/caso-exito-rpa-ia-mineria-costos/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "caso-exito-rpa-ia-mineria-costos",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/caso-exito-rpa-ia-mineria-costos/header.jpeg",
     alt: "Automatización RPA e IA en minería del cobre Chile",
+  },
+  cta: {
+    titulo: "¿Quieres reducir costos con RPA e IA?",
+    texto: "Evaluamos tu proceso y te decimos dónde está el ahorro real.",
+    botonLabel: "Evaluar mi caso",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver más casos de éxito",
+    linkUrl: "/casos-exito",
   },
   content: (
     <>
@@ -104,11 +111,8 @@ export const post = {
 
       <section className="space-y-3">
         <p className={styles.p}>
-          Si gestionas proyectos de automatización como este, conoce <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a> — nuestra herramienta para gestionar proyectos, recursos y clientes de consultoras de tecnología.
+          Si gestionas proyectos de automatización como este, conoce <a href="/projects" className="text-cyan-400 hover:underline font-semibold">Robotipy Projects</a>, nuestra herramienta para gestionar proyectos, recursos y clientes de consultoras de tecnología.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="¿Quieres algo similar? Contáctanos" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/chatbots-ia-ecommerce.js
+++ b/app/[locale]/blog/_assets/posts/chatbots-ia-ecommerce.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/chatbots-ia-ecommerce/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "chatbots-ia-ecommerce",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/chatbots-ia-ecommerce/header.jpeg", 
     alt: "Chatbots IA Ecommerce",
+  },
+  cta: {
+    titulo: "¿Quieres un chatbot que venda y resuelva?",
+    texto: "Diseñamos asistentes conectados a tu ERP, CRM y pasarela de pagos.",
+    botonLabel: "Descubre nuestras soluciones de chatbot",
+    botonUrl: "/chatbot",
+    linkLabel: "Habla con nosotros",
+    linkUrl: "/contact-us",
   },
   content: (
     <>
@@ -78,9 +85,6 @@ export const post = {
         <p className={styles.p}>
           En <strong>Robotipy</strong>, desarrollamos asistentes virtuales que se conectan profundamente con tu infraestructura tecnológica, transformando el chat en un canal de ingresos real.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="Descubre nuestras soluciones de Chatbot" link="/chatbot" type="secondary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/como-calcular-el-roi-en-proyectos-rpa.js
+++ b/app/[locale]/blog/_assets/posts/como-calcular-el-roi-en-proyectos-rpa.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/como-calcular-el-roi-en-proyectos-rpa/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   // The unique slug to use in the URL. It's also used to generate the canonical URL.
@@ -28,6 +27,14 @@ export const post = {
     // The relative URL of the same image to use in the Open Graph meta tags & the Schema Markup JSON-LD.
     urlRelative: "/blog/como-calcular-el-roi-en-proyectos-rpa/header.jpeg",
     alt: "Como Calcular el ROI en Proyectos RPA",
+  },
+  cta: {
+    titulo: "¿Quieres calcular el ROI de tu automatización?",
+    texto: "Usa nuestra calculadora y obtén una estimación precisa en menos de 3 minutos.",
+    botonLabel: "Calcula tu ROI",
+    botonUrl: "/roi-calculator",
+    linkLabel: "Habla con nosotros",
+    linkUrl: "/contact-us",
   },
   // The actual content of the article that will be shown under the <h1> title in the article page.
   content: (
@@ -59,7 +66,7 @@ export const post = {
           Un estudio de Deloitte reveló que solo el 31% de las empresas mide el
           ROI de sus automatizaciones, lo que limita su capacidad de escalar.
           Esta falta de medición no es un problema contable; es un freno
-          estratégico que mantiene a su empresa atada a procesos lentos y
+          estratégico que mantiene a tu empresa atada a procesos lentos y
           obsoletos.
         </p>
       </section>
@@ -79,7 +86,7 @@ export const post = {
         </p>
         <p className={styles.p}>
           Para un líder comercial, entender estos costos es una evaluación de
-          riesgos. Antes de aprobar cualquier proyecto, considere los siguientes
+          riesgos. Antes de aprobar cualquier proyecto, considera los siguientes
           puntos:
         </p>
         <ul className={styles.ul}>
@@ -93,7 +100,7 @@ export const post = {
             <strong className={styles.strong}>
               La Inversión en Implementación:
             </strong>{" "}
-            A menos que tenga un equipo interno especializado, necesitará un
+            A menos que tengas un equipo interno especializado, necesitarás un
             socio para desarrollar y desplegar los robots. Los honorarios de
             consultoría son una parte significativa del presupuesto y dependen
             de la complejidad del proceso.
@@ -102,11 +109,11 @@ export const post = {
             <strong className={styles.strong}>Mantenimiento y Soporte:</strong>{" "}
             Los robots, como cualquier activo, necesitan mantenimiento. Este
             costo anual, usualmente un porcentaje del licenciamiento, garantiza
-            que su inversión siga generando valor a largo plazo
+            que tu inversión siga generando valor a largo plazo
           </li>
           <li className={styles.li}>
             <strong className={styles.strong}>El Costo del Cambio:</strong>{" "}
-            Quizás el costo más subestimado es el humano. Capacitar a su equipo
+            Quizás el costo más subestimado es el humano. Capacitar a tu equipo
             y gestionar la transición es fundamental para que la automatización
             sea adoptada y no rechazada.
           </li>
@@ -294,16 +301,6 @@ export const post = {
           No dejes que tu empresa siga atada a procesos obsoletos. Mide tus
           procesos, calcula el potencial y toma la decisión basada en datos.
         </p>
-      </section>
-      <section className="space-y-3">
-        <h3 className={styles.h3}>¿Quieres Calcular tu Propio ROI?</h3>
-        <p className={styles.p}>
-          Te invitamos a usar nuestra Calculadora de ROI para RPA | Robotipy y
-          obtén una estimación precisa en menos de 3 minutos.
-        </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="Calculadora de ROI para RPA" link="/roi-calculator" type="quaternary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/porque-elegir-rocketbot.js
+++ b/app/[locale]/blog/_assets/posts/porque-elegir-rocketbot.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles.js";
 import thumbnail from "@/public/blog/porque-elegir-rocketbot/header.jpeg"; // TODO: Replace
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "porque-elegir-rocketbot",
@@ -20,6 +19,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/porque-elegir-rocketbot/header.jpeg", // TODO: Update
     alt: "Porque Elegir Rocketbot",
+  },
+  cta: {
+    titulo: "¿Pagas licencias de RPA que penalizan tu escalabilidad?",
+    texto: "Evaluamos tu ecosistema y te mostramos el ahorro de TCO con Rocketbot.",
+    botonLabel: "Agenda una evaluación técnica",
+    botonUrl: "/contact-us",
+    linkLabel: "Conoce RPA con Rocketbot",
+    linkUrl: "/rpa",
   },
   content: (
     <>
@@ -113,14 +120,11 @@ export const post = {
         Si buscas una herramienta que te permita escalar sin penalizarte, que te dé la libertad técnica de Python y que te ofrezca un soporte cercano de clase mundial, la respuesta es clara.
         </p>
         <p className={styles.p}>Rocketbot no es solo una alternativa económica; es la evolución lógica del RPA hacia un modelo más eficiente, abierto y escalable.</p>
-        <p className={styles.p}>Deje de pagar costos de licencias que penalizan su escalabilidad. 
-          Agenda una evaluación técnica de su ecosistema actual y reciba una propuesta concreta que demuestre la reducción inmediata en su Costo Total de Propiedad (TCO) gracias a la arquitectura de <a href="https://rocketbot.io/" target="_blank">Rocketbot</a>.</p>
-        <div className="flex justify-center mt-5 py-5">
-          <ButtonMain text="Contactanos" link="/contact-us" noblank={true} />
-        </div>
+        <p className={styles.p}>Deja de pagar costos de licencias que penalizan tu escalabilidad.
+          Agenda una evaluación técnica de tu ecosistema actual y recibe una propuesta concreta que demuestra la reducción inmediata en tu Costo Total de Propiedad (TCO) gracias a la arquitectura de <a href="https://rocketbot.io/" target="_blank">Rocketbot</a>.</p>
       </section>
-      
-       
+
+
     </>
   ),
 };

--- a/app/[locale]/blog/_assets/posts/que-es-rpa.js
+++ b/app/[locale]/blog/_assets/posts/que-es-rpa.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
   import { styles } from "../styles";
 import thumbnail from "@/public/blog/que-es-rpa/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "que-es-rpa",
@@ -21,6 +20,14 @@ export const post = {
       src: thumbnail,
       urlRelative: "/blog/que-es-rpa/header.jpeg",
     alt: "¿Qué es RPA?",
+  },
+  cta: {
+    titulo: "¿Quieres saber qué procesos de tu empresa puedes automatizar?",
+    texto: "Identificamos los procesos con mejor retorno y te proponemos por dónde empezar.",
+    botonLabel: "Agenda una consultoría gratuita",
+    botonUrl: "/contact-us",
+    linkLabel: "Calcula tu ROI",
+    linkUrl: "/roi-calculator",
   },
   content: (
     <>
@@ -105,9 +112,6 @@ export const post = {
         <p className={styles.p}>
           En <strong>Robotipy</strong>, ayudamos a las empresas a identificar estos procesos y a implementar soluciones de automatización que generan un retorno de inversión real.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="Agenda una Consultoría Gratuita" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),

--- a/app/[locale]/blog/_assets/posts/que-procesos-de-sap-se-pueden-automatizar-con-rpa.js
+++ b/app/[locale]/blog/_assets/posts/que-procesos-de-sap-se-pueden-automatizar-con-rpa.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/que-procesos-de-sap-se-pueden-automatizar-con-rpa/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 const linkCls = "text-accent underline-offset-2 hover:underline";
 const IntLink = ({ href, children }) => (
@@ -101,6 +100,15 @@ export const post = {
     alt: "Automatización de procesos de SAP con RPA",
   },
   faq: faqs,
+  cta: {
+    titulo: "¿Tienes un proceso de SAP que hoy se hace a mano?",
+    texto:
+      "Escríbenos y lo evaluamos sin compromiso: te decimos si conviene automatizarlo con RPA, por API o una mezcla de las dos.",
+    botonLabel: "Evaluar mi proceso de SAP",
+    botonUrl: "/contact-us",
+    linkLabel: "Cómo calcular el ROI",
+    linkUrl: "/roi-calculator",
+  },
   content: (
     <>
       {/* ── INTRO ── */}
@@ -304,7 +312,7 @@ export const post = {
         <p className={styles.p}>
           La cuenta es directa. Tomas las horas mensuales que el equipo dedica hoy a la tarea, las
           multiplicas por el costo de esa hora, y lo comparas con el costo de construir y mantener el
-          robot. Sumá del lado del beneficio lo que es más difícil de poner en un número pero pesa: los
+          robot. Suma del lado del beneficio lo que es más difícil de poner en un número pero pesa: los
           errores que dejas de cometer, el reproceso que se evita y la gente que vuelve a tareas de más
           valor.
         </p>
@@ -312,8 +320,8 @@ export const post = {
           Un proceso de carga que ocupa a dos personas medio día cada día{" "}
           <IntLink href="/blog/caso-exito-rpa-ia-mineria-costos">se paga solo en pocos meses</IntLink>.
           Por eso recomendamos empezar por un proceso de alto volumen y reglas claras: el primer robot
-          tiene que demostrar el caso para que el resto de la organización lo acompañe. Si querés
-          ponerle números a tu caso puntual, podés usar nuestra{" "}
+          tiene que demostrar el caso para que el resto de la organización lo acompañe. Si quieres
+          ponerle números a tu caso puntual, puedes usar nuestra{" "}
           <IntLink href="/roi-calculator">calculadora de ROI de automatización</IntLink> o pedirnos un
           assessment del proceso.
         </p>
@@ -323,8 +331,8 @@ export const post = {
       <section id="empezar" className="space-y-4 scroll-mt-24">
         <h2 className={styles.h2}>Por dónde empezar</h2>
         <p className={styles.p}>
-          No arranques por el proceso más complejo ni por el que más te molesta. Arrancá por el que
-          tenga la mejor combinación de volumen alto, reglas estables y datos limpios. Documentá cómo
+          No arranques por el proceso más complejo ni por el que más te molesta. Arranca por el que
+          tenga la mejor combinación de volumen alto, reglas estables y datos limpios. Documenta cómo
           se hace hoy, paso a paso, antes de automatizar nada. Esa documentación es la mitad del
           proyecto y es lo que permite que el robot se construya bien a la primera.
         </p>
@@ -351,23 +359,6 @@ export const post = {
         </div>
       </section>
 
-      {/* ── CTA ── */}
-      <div className={ui.cta}>
-        <h2 className={ui.ctaTitle}>¿Tenés un proceso de SAP que hoy se hace a mano?</h2>
-        <p className={ui.ctaText}>
-          Escribinos y lo evaluamos sin compromiso: te decimos si conviene automatizarlo con RPA, por
-          API o una mezcla de las dos.
-        </p>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <ButtonMain link="/contact-us" text="Evaluar mi proceso de SAP" />
-          <Link
-            href="/blog/como-calcular-el-roi-en-proyectos-rpa"
-            className="inline-block px-7 py-3 rounded-full border border-white/30 text-white font-semibold hover:border-white/60 transition-colors"
-          >
-            Cómo calcular el ROI
-          </Link>
-        </div>
-      </div>
     </>
   ),
 };

--- a/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
+++ b/app/[locale]/blog/_assets/posts/rpa-con-peras-y-manzanas.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/rpa-con-peras-y-manzanas/header.jpeg";
-import ButtonMain from "@/components/ButtonMain.js";
 
 const faqs = [
   {
@@ -141,6 +140,15 @@ export const post = {
     alt: "RPA con peras y manzanas",
   },
   faq: faqs,
+  cta: {
+    titulo: "¿Listo para dejar de hacer tareas repetitivas?",
+    texto:
+      "Agenda un diagnóstico gratuito de 20 minutos y te decimos qué procesos automatizar y cuánto ahorrarías.",
+    botonLabel: "Quiero mi diagnóstico gratuito",
+    botonUrl: "/contact-us",
+    linkLabel: "Ver casos de éxito",
+    linkUrl: "/blog/category/casos-de-exito",
+  },
   content: (
     <>
       {/* INTRO + STATS */}
@@ -761,20 +769,6 @@ export const post = {
         </ul>
       </section>
 
-      {/* CTA */}
-      <section>
-        <div className={ui.cta}>
-          <h2 className={ui.ctaTitle}>¿Listo para dejar de hacer tareas repetitivas?</h2>
-          <p className={ui.ctaText}>
-            Agenda un diagnóstico gratuito de 20 minutos y te mostramos exactamente qué procesos de tu empresa podemos
-            automatizar y cuánto ahorrarías.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <ButtonMain text="Quiero mi diagnóstico gratuito" link="/contact-us" type="primary" />
-            <ButtonMain text="Ver casos de éxito" link="/blog/category/casos-de-exito" type="secondary" />
-          </div>
-        </div>
-      </section>
     </>
   ),
 };

--- a/app/[locale]/blog/_assets/posts/rpa-vs-ia-agentica.js
+++ b/app/[locale]/blog/_assets/posts/rpa-vs-ia-agentica.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/rpa-vs-ia-agentica/header.jpeg"; // TODO: Replace with definitive image
-import ButtonMain from "@/components/ButtonMain.js";
 
 const linkCls = "text-accent underline-offset-2 hover:underline";
 const ExtLink = ({ href, children }) => (
@@ -174,6 +173,15 @@ export const post = {
     alt: "RPA vs IA Agéntica comparativa 2026",
   },
   faq: faqs,
+  cta: {
+    titulo: "¿No sabes si necesitas RPA, IA o ambos?",
+    texto:
+      "Analizamos tus procesos y te decimos la mejor tecnología para cada uno, sin venderte algo que no necesitas.",
+    botonLabel: "Agenda tu evaluación gratuita",
+    botonUrl: "/contact-us",
+    linkLabel: "Calcula tu ROI",
+    linkUrl: "/roi-calculator",
+  },
   content: (
     <>
       {/* ── INTRO ── */}
@@ -962,23 +970,6 @@ export const post = {
         </ul>
       </section>
 
-      {/* ── CTA ── */}
-      <div className={ui.cta}>
-        <h2 className={ui.ctaTitle}>¿No sabes si necesitas RPA, IA o ambos?</h2>
-        <p className={ui.ctaText}>
-          Analizamos tus procesos y te decimos cuál es la mejor tecnología para cada uno, sin
-          venderte algo que no necesitas.
-        </p>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <ButtonMain link="/contact-us" text="Agenda tu evaluación gratuita" />
-          <Link
-            href="/roi-calculator"
-            className="inline-block px-7 py-3 rounded-full border border-white/30 text-white font-semibold hover:border-white/60 transition-colors"
-          >
-            Calcula tu ROI
-          </Link>
-        </div>
-      </div>
     </>
   ),
 };

--- a/app/[locale]/blog/_assets/posts/tendencias-automatizacion-2025.js
+++ b/app/[locale]/blog/_assets/posts/tendencias-automatizacion-2025.js
@@ -3,7 +3,6 @@ import { categories, categorySlugs } from "../categories.js";
 import { authors, authorSlugs } from "../authors.js";
 import { styles } from "../styles";
 import thumbnail from "@/public/blog/tendencias-automatizacion-2025/header.jpeg"; // TODO: Replace
-import ButtonMain from "@/components/ButtonMain.js";
 
 export const post = {
   slug: "tendencias-automatizacion-2025",
@@ -21,6 +20,14 @@ export const post = {
     src: thumbnail,
     urlRelative: "/blog/tendencias-automatizacion-2025/header.jpeg", // TODO: Update
     alt: "Tendencias Automatizacion 2025",
+  },
+  cta: {
+    titulo: "¿Tu empresa está lista para lo que viene?",
+    texto: "Te ayudamos a integrar RPA, IA y análisis de datos en una sola estrategia.",
+    botonLabel: "Prepara tu empresa",
+    botonUrl: "/contact-us",
+    linkLabel: "Calcula tu ROI",
+    linkUrl: "/roi-calculator",
   },
   content: (
     <>
@@ -70,9 +77,6 @@ export const post = {
         <p className={styles.p}>
           El 2025 será el año de la integración. Las tecnologías dejarán de verse como silos separados y comenzarán a trabajar en orquesta. Las empresas que logren unificar RPA, IA y análisis de datos tendrán una ventaja competitiva inalcanzable para quienes sigan operando manualmente.
         </p>
-        <div className="flex justify-center mt-4">
-          <ButtonMain text="Prepara tu empresa para el futuro" link="/contact-us" type="primary"/>
-        </div>
       </section>
     </>
   ),


### PR DESCRIPTION
## Qué

Implementa la mini-spec de "Cierre de post". El final pedía la conversión varias veces (caja CTA + autor en medio + otra caja), lo que cansaba en vez de convertir. Ahora es un template uniforme para todos los posts.

## Orden del final (nuevo)
1. Contenido del artículo
2. FAQ (acordeón)
3. **Sigue leyendo** (lectura relacionada)
4. **Bloque de AUTOR** (genera confianza)
5. **UNA sola caja de cierre (CTA contextual)**, al final

> Nota: dejé "Sigue leyendo" antes del autor para que la **caja de CTA sea el último elemento** y el par autor → CTA quede junto. Si prefieres "Sigue leyendo" después del CTA, lo muevo.

## Caja de cierre (componente `ArticleCta`)
- **Una sola por post**, contextual (un post de SAP cierra con oferta de SAP).
- Color de marca: tarjeta **navy `#2D3648`** + **acento teal real del sitio** (`#039695`, confirmado contra el `CTA` del home). Se quita el teal "pegado de otro template" (la banda full‑teal).
- **Un botón principal** (conversión, mismo estilo navy + borde teal que el home) **+ un link de texto secundario** (recurso de apoyo). No dos botones que compiten.
- Estructura: título‑gancho + 1 línea + botón + link.

## Variables del template (por post)
Cada post define `cta: { titulo, texto, botonLabel, botonUrl, linkLabel, linkUrl }`. La plantilla `[articleId]/page.js` lo renderiza al final (con un default por si falta). El autor sale de `author` (foto real, nombre, cargo, bio); solo personas reales.

## Limpieza aplicada a los 16 posts
- Se quitó la caja/botón de CTA inline duplicado de cada post, **conservando** el contenido real (párrafos "Robotipy Projects", bloques "Insight", listas de enlaces internos, FAQ).
- Se agregó el `cta` contextual a cada post.
- Copy unificado a **tuteo neutro** (sin voseo ni ustedeo: "Escríbenos", "puedes", "Deja de pagar", "tu empresa") y **sin em-dash** (se reemplazaron los que había).
- Se eliminaron imports de `ButtonMain` que quedaron sin uso.

## Verificación
- `next build` pasa completo.
- Runtime (servidor local): el cierre renderiza en orden autor → **una** caja CTA navy; el botón principal apunta a su destino real y el link secundario también; la banda genérica teal ya no aparece; los 16 posts tienen `cta` y ninguno conserva botones inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_