### PR TITLE
Repuntar CTAs de casos de éxito a /success-cases y ampliar /rocketbot a Chile o Argentina

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -68,7 +68,7 @@ const EVERGREEN = [
   {
     tag: "Casos de éxito",
     title: "Casos reales de automatización",
-    href: "/casos-exito",
+    href: "/success-cases",
     meta: "Resultados medibles",
   },
   {

--- a/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-financiera-agroindustria.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-financiera-agroindustria.js
@@ -26,7 +26,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-ordenes-sap-siderurgia.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-automatizacion-ordenes-sap-siderurgia.js
@@ -26,7 +26,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/blog/_assets/posts/caso-exito-cartolas-factoring-vitivinicola.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-cartolas-factoring-vitivinicola.js
@@ -26,7 +26,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/blog/_assets/posts/caso-exito-conciliacion-bancaria-agropecuario.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-conciliacion-bancaria-agropecuario.js
@@ -26,7 +26,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/blog/_assets/posts/caso-exito-inteligencia-mercado-agronegocios.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-inteligencia-mercado-agronegocios.js
@@ -25,7 +25,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/blog/_assets/posts/caso-exito-logistica.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-logistica.js
@@ -27,7 +27,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/blog/_assets/posts/caso-exito-rpa-ia-mineria-costos.js
+++ b/app/[locale]/blog/_assets/posts/caso-exito-rpa-ia-mineria-costos.js
@@ -26,7 +26,7 @@ export const post = {
     botonLabel: "Evaluar mi caso",
     botonUrl: "/contact-us",
     linkLabel: "Ver más casos de éxito",
-    linkUrl: "/casos-exito",
+    linkUrl: "/success-cases",
   },
   content: (
     <>

--- a/app/[locale]/rocketbot/page.js
+++ b/app/[locale]/rocketbot/page.js
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }) {
     title:
       "Implementación de Rocketbot en Chile y LatAm | Robotipy, Platinum Partner",
     description:
-      "Robotipy es Platinum Partner de Rocketbot, el tier más alto de certificación. Su fundador fue desarrollador de Rocketbot 6 años. +80 proyectos en Chile, Argentina, España y LatAm.",
+      "¿Buscas quién implementa Rocketbot en Chile o Argentina? Robotipy es Platinum Partner de Rocketbot, el tier más alto, con +80 proyectos en LatAm y España.",
     canonicalUrlRelative: "/rocketbot",
   });
 }
@@ -156,7 +156,7 @@ const RocketbotPage = async ({ params }) => {
             Robotipy: Platinum Partner de Rocketbot en Chile y Latinoamérica
           </h1>
           <p className="max-w-3xl text-[18px] leading-[1.7] text-white/85">
-            ¿Buscas quién implementa Rocketbot en Chile? Robotipy es{" "}
+            ¿Buscas quién implementa Rocketbot en Chile o Argentina? Robotipy es{" "}
             <strong className="text-white">
               Platinum Partner de Rocketbot, el tier más alto del programa de
               certificación
@@ -175,7 +175,7 @@ const RocketbotPage = async ({ params }) => {
           <div className="mt-8 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
             <ButtonMain link="/contact-us" text="Evaluar mi proceso" type="primary" rounded noblank />
             <Link
-              href="/casos-exito"
+              href="/success-cases"
               className="text-[15px] font-semibold text-accent underline-offset-4 hover:underline"
             >
               Ver nuestros casos de éxito
@@ -278,7 +278,7 @@ const RocketbotPage = async ({ params }) => {
             <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
               <ButtonMain link="/contact-us" text="Evaluar mi proceso" type="primary" rounded noblank />
               <Link
-                href="/casos-exito"
+                href="/success-cases"
                 className="text-[15px] font-semibold text-accent underline-offset-4 hover:underline"
               >
                 Ver nuestros casos de éxito


### PR DESCRIPTION
## Qué

Dos arreglos pedidos:

### 1. "Ver casos de éxito" iba a una página que fallaba
El CTA apuntaba a `/casos-exito` (al usuario le daba "Failed to load chunk / Something went wrong"). Se reapunta a **`/success-cases`**, el listado que funciona, en:
- `/rocketbot` (los dos CTA "Ver nuestros casos de éxito").
- El `cta` de los 7 posts de casos de éxito ("Ver más casos de éxito").
- La tarjeta evergreen "Casos reales de automatización" de "Sigue leyendo" (plantilla del artículo).

### 2. `/rocketbot` ahora ataca la intención Chile **o** Argentina
- BLUF (primer párrafo): "¿Buscas quién implementa Rocketbot en Chile o Argentina?".
- **meta description** alineada: "¿Buscas quién implementa Rocketbot en Chile o Argentina? Robotipy es Platinum Partner de Rocketbot, el tier más alto, con +80 proyectos en LatAm y España."

## Verificación
- `next build` pasa.
- Runtime: la meta y el BLUF muestran "Chile o Argentina"; el CTA resuelve a `/es/success-cases`; ya no queda ningún `/casos-exito` en la página `/rocketbot`.

## Nota
- Quedó **un** enlace inline a `/casos-exito` en `app/[locale]/ai-info/page.js` (preexistente, fuera de lo que toqué). Si `/casos-exito` está realmente roto y prefieres que todo apunte a `/success-cases`, lo cambio también. Vale la pena revisar por separado por qué `/casos-exito` falla al cargar el chunk (puede ser un error real de esa página, no solo del enlace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_