### PR TITLE
Post cuentas por pagar: sumar párrafo de transparencia (versión original)

### DIFF
--- a/app/[locale]/blog/_assets/posts/como-automatizar-cuentas-por-pagar-y-carga-de-facturas.js
+++ b/app/[locale]/blog/_assets/posts/como-automatizar-cuentas-por-pagar-y-carga-de-facturas.js
@@ -229,7 +229,13 @@ export const post = {
         </h2>
         <p className={styles.p}>
           No todo proceso de AP está listo para un robot, y prometer lo contrario
-          sería venderte humo.
+          sería venderte humo. El mes pasado varias empresas nos pidieron
+          automatizar sus cuentas por pagar y, al hacer la cuenta juntos, el ROI
+          no cerraba: el volumen era bajo o el proceso todavía no estaba estable.
+          Se los dijimos de frente y no avanzamos. Preferimos no vender un
+          proyecto que no se iba a pagar antes que cerrar una venta y dejar a un
+          cliente con un robot que no le rinde. Esa franqueza es la que después
+          hace que vuelvan cuando el caso sí cierra.
         </p>
         <p className={styles.p}>
           Si procesas 30 facturas al mes, el caso no cierra: el tiempo de


### PR DESCRIPTION
## Qué

El borrador "original" que me pasaste trae, en la sección **"Cuándo NO conviene automatizar tus cuentas por pagar todavía"**, un párrafo que la versión ya mergeada (PR #43) no tenía: la anécdota de clientes a los que no les vendimos porque el ROI no cerraba ("Preferimos no vender un proyecto que no se iba a pagar..."). Refuerza el tono honesto del post.

Es el único cambio respecto de lo ya publicado; el resto del contenido es idéntico.

## Verificación
- `next build` pasa.
- Sin em-dashes ni emojis-viñeta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_