### PR TITLE
Actualizar subtítulo del post de cuentas por pagar

### DIFF
--- a/app/[locale]/blog/_assets/posts/como-automatizar-cuentas-por-pagar-y-carga-de-facturas.js
+++ b/app/[locale]/blog/_assets/posts/como-automatizar-cuentas-por-pagar-y-carga-de-facturas.js
@@ -44,7 +44,7 @@ export const post = {
   locale: "es",
   title: "Cómo automatizar cuentas por pagar y la carga de facturas",
   description:
-    "Guía práctica para automatizar cuentas por pagar y la carga de facturas con RPA: cómo funciona, qué procesos conviene atacar primero y cómo medir el ROI.",
+    "Te contamos cómo automatizar cuentas por pagar y la carga de facturas: por dónde empezar, cuándo el robot rinde de verdad y cómo sacar la cuenta del ROI",
   keywords: [
     "automatizar cuentas por pagar",
     "automatización de facturas",


### PR DESCRIPTION
## Qué

Cambia el subtítulo del post `como-automatizar-cuentas-por-pagar-y-carga-de-facturas` por la bajada pedida:

> "Te contamos cómo automatizar cuentas por pagar y la carga de facturas: por dónde empezar, cuándo el robot rinde de verdad y cómo sacar la cuenta del ROI"

Es el campo `description` del post, que en el blog se renderiza **bajo el H1 (subtítulo visible) y también como meta description / og:description**. Conserva keywords útiles (cuentas por pagar, facturas, ROI).

## Verificación
- `next build` pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_