### PR TITLE
Corregir diseño y contenido de /rocketbot/chile y /rocketbot/argentina

### DIFF
--- a/app/[locale]/rocketbot/argentina/page.js
+++ b/app/[locale]/rocketbot/argentina/page.js
@@ -33,6 +33,7 @@ export async function generateMetadata() {
   return getSEOTags({
     locale: "es",
     availableLocales: ["es"],
+    ogLocale: "es_LA",
     title:
       "Implementación de Rocketbot en Argentina | Robotipy, Platinum Partner",
     description:
@@ -102,7 +103,7 @@ const RocketbotArgentinaPage = () => {
             Rocketbot en Argentina · Platinum Partner
           </div>
           <h1 className="mb-6 font-display text-[clamp(30px,4.5vw,46px)] font-extrabold leading-[1.08] tracking-[-0.02em]">
-            Implementación de Rocketbot en Argentina, Robotipy, Platinum Partner
+            Implementación de Rocketbot en Argentina: Robotipy, Platinum Partner
           </h1>
           <p className="max-w-3xl text-[18px] leading-[1.7] text-white/85">
             ¿Buscas quién implementa Rocketbot en Argentina? Robotipy es{" "}
@@ -183,33 +184,46 @@ const RocketbotArgentinaPage = () => {
             </div>
             <div className="rounded-2xl border border-white/[0.07] bg-secondary p-6">
               <h3 className="mb-2 font-display text-[18px] font-bold text-white">
-                Estudio contable agro (en desarrollo)
+                Agronegocios
+              </h3>
+              <p className="text-[15px] leading-[1.6] text-white/75">
+                Inteligencia de mercado automatizada que consolida precios de
+                commodities, tasas y datos macro de más de 10 fuentes públicas
+                para una consultora del campo.{" "}
+                <Link
+                  href="/blog/caso-exito-inteligencia-mercado-agronegocios"
+                  className="text-accent hover:underline"
+                >
+                  Ver el caso
+                </Link>
+                .
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/[0.07] bg-secondary p-6">
+              <h3 className="mb-2 font-display text-[18px] font-bold text-white">
+                Agropecuario
+              </h3>
+              <p className="text-[15px] leading-[1.6] text-white/75">
+                Conciliación multi-banco integrada con el ERP Finnegans en un
+                grupo agropecuario: lo que tomaba horas, ahora en minutos.{" "}
+                <Link
+                  href="/blog/caso-exito-conciliacion-bancaria-agropecuario"
+                  className="text-accent hover:underline"
+                >
+                  Ver el caso
+                </Link>
+                .
+              </p>
+            </div>
+            <div className="rounded-2xl border border-white/[0.07] bg-secondary p-6">
+              <h3 className="mb-2 font-display text-[18px] font-bold text-white">
+                Estudio contable agro (en implementación)
               </h3>
               <p className="text-[15px] leading-[1.6] text-white/75">
                 Bot que procesa comprobantes y arma el Libro IVA Compras de AFIP.
-                En desarrollo.
               </p>
             </div>
           </div>
-
-          <p className="mt-6 max-w-3xl text-[15px] leading-[1.7] text-white/70">
-            Sumamos contexto regional ya publicado en el blog:{" "}
-            <Link
-              href="/blog/caso-exito-inteligencia-mercado-agronegocios"
-              className="text-accent hover:underline"
-            >
-              inteligencia de mercado en agronegocios
-            </Link>{" "}
-            que consolida precios de commodities y datos macro de más de 10
-            fuentes, y una{" "}
-            <Link
-              href="/blog/caso-exito-conciliacion-bancaria-agropecuario"
-              className="text-accent hover:underline"
-            >
-              conciliación multi-banco integrada con ERP
-            </Link>
-            .
-          </p>
           <p className="mt-4 text-[13px] text-white/50">
             Casos descritos por industria para resguardar la confidencialidad de
             cada cliente.

--- a/app/[locale]/rocketbot/chile/page.js
+++ b/app/[locale]/rocketbot/chile/page.js
@@ -48,12 +48,47 @@ const casos = [
     detalle:
       "Bot de factoring que lee los TXT del SII, actualiza SAP y emite un reporte, ejecutándose cada 30 minutos sin errores.",
   },
+  {
+    rubro: "Minería del cobre",
+    detalle: (
+      <>
+        RPA más un agente de IA que automatiza los reportes de costos y permite
+        consultar los datos en lenguaje natural 24/7, eliminando la dependencia
+        de una sola persona.{" "}
+        <Link
+          href="/blog/caso-exito-rpa-ia-mineria-costos"
+          className="text-accent hover:underline"
+        >
+          Ver el caso
+        </Link>
+        .
+      </>
+    ),
+  },
+  {
+    rubro: "Siderurgia",
+    detalle: (
+      <>
+        Automatización del ciclo completo de órdenes de compra en SAP, de la
+        lectura del documento a la creación del pedido, con cero errores de
+        transcripción entre tres sistemas.{" "}
+        <Link
+          href="/blog/caso-exito-automatizacion-ordenes-sap-siderurgia"
+          className="text-accent hover:underline"
+        >
+          Ver el caso
+        </Link>
+        .
+      </>
+    ),
+  },
 ];
 
 export async function generateMetadata() {
   return getSEOTags({
     locale: "es",
     availableLocales: ["es"],
+    ogLocale: "es_LA",
     title: "Implementación de Rocketbot en Chile | Robotipy, Platinum Partner",
     description:
       "Robotipy implementa Rocketbot en Chile: automatización de procesos en SAP, conciliaciones, minería y retail. Platinum Partner, fundador con 6 años desarrollando Rocketbot.",
@@ -122,7 +157,7 @@ const RocketbotChilePage = () => {
             Rocketbot en Chile · Platinum Partner
           </div>
           <h1 className="mb-6 font-display text-[clamp(30px,4.5vw,46px)] font-extrabold leading-[1.08] tracking-[-0.02em]">
-            Implementación de Rocketbot en Chile, Robotipy, Platinum Partner
+            Implementación de Rocketbot en Chile: Robotipy, Platinum Partner
           </h1>
           <p className="max-w-3xl text-[18px] leading-[1.7] text-white/85">
             ¿Buscas quién implementa Rocketbot en Chile? Robotipy es{" "}

--- a/libs/seo.js
+++ b/libs/seo.js
@@ -46,6 +46,7 @@ export const getSEOTags = ({
   extraTags,
   locale,
   availableLocales,
+  ogLocale,
 } = {}) => {
   const activeLocale =
     locale && routing.locales.includes(locale) ? locale : routing.defaultLocale;
@@ -81,7 +82,7 @@ export const getSEOTags = ({
           alt: config.appName,
         },
       ],
-      locale: ogLocaleMap[activeLocale] || "es_ES",
+      locale: ogLocale || ogLocaleMap[activeLocale] || "es_ES",
       type: "website",
     },
 


### PR DESCRIPTION
## Qué cambia

Change request sobre las páginas por país de Rocketbot ya publicadas.

### SEO / Open Graph
- Nuevo parámetro `ogLocale` en `getSEOTags` (`libs/seo.js`) para permitir override del `og:locale`.
- Ambas páginas pasan `ogLocale: "es_LA"` (antes heredaban `es_ES`), más representativo del público de Chile y Argentina. Canonical y hreflang siguen apuntando solo a `es`.

### /rocketbot/chile
- H1: coma reemplazada por dos puntos → "Implementación de Rocketbot en Chile: Robotipy, Platinum Partner".
- Dos casos nuevos por industria, enlazados a casos públicos del blog:
  - Minería del cobre (RPA + agente de IA para reportes de costos) → `/blog/caso-exito-rpa-ia-mineria-costos`.
  - Siderurgia (ciclo completo de órdenes de compra en SAP) → `/blog/caso-exito-automatizacion-ordenes-sap-siderurgia`.

### /rocketbot/argentina
- H1: coma reemplazada por dos puntos → "Implementación de Rocketbot en Argentina: Robotipy, Platinum Partner".
- Se promueven dos casos del blog a tarjetas con enlace:
  - Agronegocios (inteligencia de mercado) → `/blog/caso-exito-inteligencia-mercado-agronegocios`.
  - Agropecuario (conciliación bancaria, Finnegans) → `/blog/caso-exito-conciliacion-bancaria-agropecuario`.
- Se elimina el párrafo "Sumamos contexto regional…".
- Se corrige el duplicado "en desarrollo" → "en implementación" en el caso de estudio contable agro.

### Cumplimiento de confidencialidad
- No se nombran clientes finales (descripción por rubro).
- No se publican montos, tarifas, RUTs ni ROI estimados de propuesta.
- No se usan datos de los proyectos vetados (DRM/Lomas Bayas, AXA/Confort Risk, Caimicorp).

## Validación
- `next build` OK.
- Verificación en runtime: `og:locale=es_LA` en ambas, H1 con dos puntos, tarjetas y enlaces nuevos presentes, conteo "en desarrollo" = 0, párrafo "Sumamos contexto" = 0, `FAQPage` JSON-LD presente, sin em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_