### PR TITLE
Calculadora ROI: reporte PDF en URL limpia e imprimible

### DIFF
--- a/app/[locale]/roi-calculator/page.js
+++ b/app/[locale]/roi-calculator/page.js
@@ -6,6 +6,17 @@ import { toast } from "react-hot-toast";
 import Header from "@/components/Header";
 import config from "@/config";
 import apiClient from "@/libs/api";
+import {
+  computeROI,
+  fmtMoney,
+  fmtPct,
+  parseParams,
+  DEFAULT_FORM,
+  SHAREABLE_NUM,
+  TOOL_KEYS,
+  WORKING_DAYS_PER_MONTH,
+  WORKING_HOURS_PER_DAY,
+} from "@/libs/roi";
 
 // Precios de referencia de Rocketbot. Solo se usan como conveniencia cuando el
 // usuario elige "Rocketbot" en el selector de herramienta; el campo de costo
@@ -30,10 +41,6 @@ const LICENSE_THRESHOLDS = {
   },
 };
 
-const DISCOUNT_RATE = 0.10;
-const WORKING_DAYS_PER_MONTH = 22;
-const WORKING_HOURS_PER_DAY = 8;
-
 const TEMPLATE_KEYS = ["facturacion", "conciliacion", "reportes", "datos", "validacion", "otro"];
 
 const TEMPLATE_DEFAULTS = {
@@ -47,8 +54,6 @@ const TEMPLATE_DEFAULTS = {
 
 const CONTACT_URL = "/contact-us";
 
-const TOOL_KEYS = ["rocketbot", "powerautomate", "uipath", "custom", "otra", "nose"];
-
 const ALL_LICENSE_KEYS = Object.keys(ROCKETBOT_LICENSES);
 
 const licensesFromKeys = (keys) =>
@@ -56,31 +61,6 @@ const licensesFromKeys = (keys) =>
 
 const sumLicenses = (selected) =>
   ALL_LICENSE_KEYS.reduce((s, k) => s + (selected[k] ? ROCKETBOT_LICENSES[k].price : 0), 0);
-
-const DEFAULT_FORM = {
-  descripcion: "",
-  personas: 2,
-  salario: 1000,
-  diasMes: 15,
-  horasDia: 8,
-  erroresMes: 5,
-  minPorError: 30,
-  horasExtraMes: 0,
-  costoHoraExtra: 160,
-  multasMes: 0,
-  exchangeRate: 1,
-  herramienta: "rocketbot",
-  costoDesarrollo: 5800,
-  licenciasAnual: 0,
-  mantenimiento: 580,
-};
-
-// Campos numéricos que se serializan en la URL para compartir el resultado.
-const SHAREABLE_NUM = [
-  "personas", "salario", "diasMes", "horasDia", "erroresMes", "minPorError",
-  "horasExtraMes", "costoHoraExtra", "multasMes", "exchangeRate",
-  "costoDesarrollo", "licenciasAnual", "mantenimiento",
-];
 
 function deduceLicenses({ personas, horasDia, diasMes }) {
   const h = personas * horasDia * diasMes;
@@ -96,57 +76,6 @@ function deduceLicenses({ personas, horasDia, diasMes }) {
   }
   return orq ? [bot, orq] : [bot];
 }
-
-function computeROI(f) {
-  const costoHora = f.salario / (WORKING_DAYS_PER_MONTH * WORKING_HOURS_PER_DAY);
-  const totalHorasMes = f.personas * f.horasDia * f.diasMes;
-
-  const ahorroProductividad = totalHorasMes * costoHora * 12;
-  const ahorroErrores       = (f.erroresMes * f.minPorError / 60) * costoHora * 12;
-  const ahorroHorasExtra    = f.horasExtraMes * f.costoHoraExtra * 12;
-  const multasRecuperadas   = f.multasMes * 12;
-  const beneficioAnual = ahorroProductividad + ahorroErrores + ahorroHorasExtra + multasRecuperadas;
-
-  const licenciasAnualUSD = f.licenciasAnual || 0;
-  const mantenimiento = f.mantenimiento;
-  const inversionAño1   = f.costoDesarrollo + licenciasAnualUSD + mantenimiento;
-  const recurrenteAnual = licenciasAnualUSD + mantenimiento;
-
-  const benefDesc = [1, 2, 3].reduce(
-    (s, y) => s + beneficioAnual / Math.pow(1 + DISCOUNT_RATE, y), 0
-  );
-  const costoDesc =
-      inversionAño1   / Math.pow(1 + DISCOUNT_RATE, 1)
-    + recurrenteAnual / Math.pow(1 + DISCOUNT_RATE, 2)
-    + recurrenteAnual / Math.pow(1 + DISCOUNT_RATE, 3);
-
-  const VPN = benefDesc - costoDesc;
-  const ROI = costoDesc > 0 ? (VPN / costoDesc) * 100 : 0;
-  const ROI1a = inversionAño1 > 0 ? ((beneficioAnual - inversionAño1) / inversionAño1) * 100 : 0;
-  const paybackMeses = beneficioAnual > 0 ? (inversionAño1 / beneficioAnual) * 12 : 0;
-
-  return {
-    licenciasAnualUSD,
-    mantenimiento,
-    inversionAño1,
-    recurrenteAnual,
-    beneficioAnual,
-    beneficioTotal3a: beneficioAnual * 3,
-    VPN,
-    ROI,
-    ROI1a,
-    paybackMeses,
-    ahorroProductividad,
-    ahorroErrores,
-    ahorroHorasExtra,
-    multasRecuperadas,
-    costoHora,
-    totalHorasMes,
-  };
-}
-
-const fmtMoney = (n) => `$${Math.round(n || 0).toLocaleString("en-US")}`;
-const fmtPct   = (n) => `${(n || 0).toFixed(1)}%`;
 
 function track(name, params) {
   if (typeof window !== "undefined" && typeof window.gtag === "function") {
@@ -248,35 +177,10 @@ const ROICalculator = () => {
     startTracked.current = true;
     track("roi_wizard_start");
 
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.size === 0) return;
-
-    const next = {};
-    SHAREABLE_NUM.forEach((key) => {
-      const raw = urlParams.get(key);
-      if (raw !== null) {
-        const v = parseFloat(raw);
-        if (Number.isFinite(v)) next[key] = v;
-      }
-    });
-    // Compatibilidad con enlaces antiguos.
-    const legacy = {
-      peopleInProcess: "personas",
-      hoursPerDay: "horasDia",
-      avgMonthlyCostPerPerson: "salario",
-    };
-    Object.entries(legacy).forEach(([param, field]) => {
-      const v = parseFloat(urlParams.get(param));
-      if (Number.isFinite(v)) next[field] = v;
-    });
-    const desc = urlParams.get("descripcion");
-    if (desc) next.descripcion = desc;
-    const herr = urlParams.get("herramienta");
-    if (herr && TOOL_KEYS.includes(herr)) next.herramienta = herr;
-
-    if (Object.keys(next).length > 0) {
-      if ("licenciasAnual" in next) setLicenciasOverridden(true);
-      setFormData((prev) => ({ ...prev, ...next }));
+    const { values, hasLicencias } = parseParams(window.location.search);
+    if (Object.keys(values).length > 0) {
+      if (hasLicencias) setLicenciasOverridden(true);
+      setFormData((prev) => ({ ...prev, ...values }));
     }
   }, []);
 
@@ -387,18 +291,19 @@ const ROICalculator = () => {
     window.location.href = `${CONTACT_URL}?additionalInfo=${encodeURIComponent(summary)}`;
   };
 
-  const buildShareUrl = () => {
+  const formParams = () => {
     const params = new URLSearchParams();
     SHAREABLE_NUM.forEach((key) => params.set(key, String(formData[key])));
     if (formData.herramienta) params.set("herramienta", formData.herramienta);
     if (formData.descripcion) params.set("descripcion", formData.descripcion);
-    return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+    return params.toString();
   };
 
   const handleCopyLink = async () => {
     track("roi_wizard_share_link");
     try {
-      await navigator.clipboard.writeText(buildShareUrl());
+      const url = `${window.location.origin}${window.location.pathname}?${formParams()}`;
+      await navigator.clipboard.writeText(url);
       toast.success(t("step4.cta.copied"));
     } catch {
       toast.error(t("step4.cta.copyError"));
@@ -407,7 +312,8 @@ const ROICalculator = () => {
 
   const handleDownloadPdf = () => {
     track("roi_wizard_download_pdf");
-    if (typeof window !== "undefined") window.print();
+    const url = `${window.location.origin}${window.location.pathname}/report?${formParams()}`;
+    window.open(url, "_blank", "noopener");
   };
 
   const submitEmailRequest = async (e) => {

--- a/app/[locale]/roi-calculator/report/page.js
+++ b/app/[locale]/roi-calculator/report/page.js
@@ -1,0 +1,10 @@
+import ROIReport from "@/components/ROIReport";
+
+export const metadata = {
+  title: "Reporte ROI | Robotipy",
+  robots: { index: false, follow: false },
+};
+
+export default function ROIReportPage() {
+  return <ROIReport />;
+}

--- a/components/ROIReport.js
+++ b/components/ROIReport.js
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/routing";
+import { computeROI, fmtMoney, fmtPct, DEFAULT_FORM, parseParams } from "@/libs/roi";
+
+const printCss = `
+@media print {
+  .roi-no-print { display: none !important; }
+  [id^="zsiq"], .zsiq_floatmain, #zsiqbtn, .zsiq_flt_rel, .skip-to-content { display: none !important; }
+  html, body { background: #fff !important; }
+  @page { margin: 18mm; }
+}
+`;
+
+function Row({ label, value, strong }) {
+  return (
+    <div
+      className={`flex items-center justify-between py-2 ${
+        strong ? "border-t border-gray-300 font-semibold" : "border-b border-gray-100"
+      }`}
+    >
+      <span className={strong ? "text-[#00182B]" : "text-gray-600"}>{label}</span>
+      <span className="text-[#00182B]">{value}</span>
+    </div>
+  );
+}
+
+export default function ROIReport() {
+  const t = useTranslations("roiCalculator");
+  const [form, setForm] = useState(null);
+
+  useEffect(() => {
+    const { values } = parseParams(window.location.search);
+    setForm({ ...DEFAULT_FORM, ...values });
+  }, []);
+
+  const calc = useMemo(() => (form ? computeROI(form) : null), [form]);
+
+  useEffect(() => {
+    if (!form) return;
+    const id = setTimeout(() => {
+      try {
+        window.print();
+      } catch {
+        /* el usuario puede usar el botón manual */
+      }
+    }, 600);
+    return () => clearTimeout(id);
+  }, [form]);
+
+  if (!form || !calc) {
+    return <main className="min-h-screen bg-white" />;
+  }
+
+  const proceso = form.descripcion || t("step4.noDescription");
+  const metrics = [
+    { label: t("step4.metrics.annualSavings"), value: fmtMoney(calc.beneficioAnual) },
+    { label: t("step4.metrics.payback"), value: `${calc.paybackMeses.toFixed(1)} ${t("step4.metrics.paybackUnit")}` },
+    { label: t("step4.metrics.roi1y"), value: fmtPct(calc.ROI1a) },
+    { label: t("step4.metrics.npv"), value: fmtMoney(calc.VPN) },
+  ];
+
+  return (
+    <main className="min-h-screen bg-white text-[#00182B]">
+      <style dangerouslySetInnerHTML={{ __html: printCss }} />
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <div className="roi-no-print mb-8 flex flex-wrap justify-end gap-3">
+          <button
+            onClick={() => window.print()}
+            className="rounded-md bg-[#039695] px-5 py-2 text-sm font-semibold text-white hover:opacity-90"
+          >
+            {t("step4.cta.pdf")}
+          </button>
+          <Link
+            href="/roi-calculator"
+            className="rounded-md border border-[#039695] px-5 py-2 text-sm font-semibold text-[#039695] hover:bg-[#039695]/5"
+          >
+            {t("report.back")}
+          </Link>
+        </div>
+
+        <header className="mb-8 border-b border-gray-200 pb-6">
+          <div className="text-lg font-bold text-[#039695]">Robotipy</div>
+          <h1 className="mt-2 text-3xl font-extrabold leading-tight">{t("hero.title")}</h1>
+          <p className="mt-2 text-gray-600">
+            {t("step4.processLabel")} <span className="text-[#00182B]">{proceso}</span>
+          </p>
+        </header>
+
+        <section className="mb-8 rounded-xl border border-gray-200 py-8 text-center">
+          <div className="text-5xl font-extrabold text-[#039695] lg:text-6xl">{fmtPct(calc.ROI)}</div>
+          <p className="mt-2 text-gray-600">{t("step4.roiHero")}</p>
+        </section>
+
+        <section className="mb-10 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          {metrics.map((m) => (
+            <div key={m.label} className="rounded-lg border border-gray-200 p-4 text-center">
+              <div className="mb-1 text-[11px] uppercase tracking-wide text-gray-500">{m.label}</div>
+              <div className="text-lg font-bold text-[#00182B]">{m.value}</div>
+            </div>
+          ))}
+        </section>
+
+        <section className="mb-8">
+          <h2 className="mb-2 text-lg font-bold">{t("step4.benefitsTitle")}</h2>
+          <Row label={t("step4.benefits.productivity")} value={fmtMoney(calc.ahorroProductividad)} />
+          <Row label={t("step4.benefits.errors")} value={fmtMoney(calc.ahorroErrores)} />
+          <Row label={t("step4.benefits.overtime")} value={fmtMoney(calc.ahorroHorasExtra)} />
+          <Row label={t("step4.benefits.fines")} value={fmtMoney(calc.multasRecuperadas)} />
+          <Row label={t("step4.benefits.total")} value={fmtMoney(calc.beneficioAnual)} strong />
+        </section>
+
+        <section className="mb-8">
+          <h2 className="mb-2 text-lg font-bold">{t("step4.investmentTitle")}</h2>
+          <Row label={t("step4.investment.development")} value={fmtMoney(form.costoDesarrollo)} />
+          <Row label={t("step4.investment.licenses")} value={fmtMoney(calc.licenciasAnualUSD)} />
+          <Row label={t("step4.investment.maintenance")} value={fmtMoney(calc.mantenimiento)} />
+          <Row label={t("step4.investment.year1")} value={fmtMoney(calc.inversionAño1)} strong />
+          <div className="flex items-center justify-between pt-2 text-sm text-gray-500">
+            <span>{t("step4.investment.recurring")}</span>
+            <span>{fmtMoney(calc.recurrenteAnual)}</span>
+          </div>
+        </section>
+
+        <p className="border-t border-gray-200 pt-4 text-xs leading-relaxed text-gray-500">
+          {t("step4.formula")}
+        </p>
+        <p className="mt-3 text-xs text-gray-400">robotipy.com</p>
+      </div>
+    </main>
+  );
+}

--- a/libs/roi.js
+++ b/libs/roi.js
@@ -1,0 +1,114 @@
+// Lógica de cálculo compartida entre la calculadora (wizard) y la vista de
+// reporte imprimible. Mantener ambas en sync importando desde aquí.
+
+export const DISCOUNT_RATE = 0.10;
+export const WORKING_DAYS_PER_MONTH = 22;
+export const WORKING_HOURS_PER_DAY = 8;
+
+export const TOOL_KEYS = ["rocketbot", "powerautomate", "uipath", "custom", "otra", "nose"];
+
+export const DEFAULT_FORM = {
+  descripcion: "",
+  personas: 2,
+  salario: 1000,
+  diasMes: 15,
+  horasDia: 8,
+  erroresMes: 5,
+  minPorError: 30,
+  horasExtraMes: 0,
+  costoHoraExtra: 160,
+  multasMes: 0,
+  exchangeRate: 1,
+  herramienta: "rocketbot",
+  costoDesarrollo: 5800,
+  licenciasAnual: 0,
+  mantenimiento: 580,
+};
+
+// Campos numéricos que se serializan en la URL para compartir/imprimir.
+export const SHAREABLE_NUM = [
+  "personas", "salario", "diasMes", "horasDia", "erroresMes", "minPorError",
+  "horasExtraMes", "costoHoraExtra", "multasMes", "exchangeRate",
+  "costoDesarrollo", "licenciasAnual", "mantenimiento",
+];
+
+export function computeROI(f) {
+  const costoHora = f.salario / (WORKING_DAYS_PER_MONTH * WORKING_HOURS_PER_DAY);
+  const totalHorasMes = f.personas * f.horasDia * f.diasMes;
+
+  const ahorroProductividad = totalHorasMes * costoHora * 12;
+  const ahorroErrores       = (f.erroresMes * f.minPorError / 60) * costoHora * 12;
+  const ahorroHorasExtra    = f.horasExtraMes * f.costoHoraExtra * 12;
+  const multasRecuperadas   = f.multasMes * 12;
+  const beneficioAnual = ahorroProductividad + ahorroErrores + ahorroHorasExtra + multasRecuperadas;
+
+  const licenciasAnualUSD = f.licenciasAnual || 0;
+  const mantenimiento = f.mantenimiento;
+  const inversionAño1   = f.costoDesarrollo + licenciasAnualUSD + mantenimiento;
+  const recurrenteAnual = licenciasAnualUSD + mantenimiento;
+
+  const benefDesc = [1, 2, 3].reduce(
+    (s, y) => s + beneficioAnual / Math.pow(1 + DISCOUNT_RATE, y), 0
+  );
+  const costoDesc =
+      inversionAño1   / Math.pow(1 + DISCOUNT_RATE, 1)
+    + recurrenteAnual / Math.pow(1 + DISCOUNT_RATE, 2)
+    + recurrenteAnual / Math.pow(1 + DISCOUNT_RATE, 3);
+
+  const VPN = benefDesc - costoDesc;
+  const ROI = costoDesc > 0 ? (VPN / costoDesc) * 100 : 0;
+  const ROI1a = inversionAño1 > 0 ? ((beneficioAnual - inversionAño1) / inversionAño1) * 100 : 0;
+  const paybackMeses = beneficioAnual > 0 ? (inversionAño1 / beneficioAnual) * 12 : 0;
+
+  return {
+    licenciasAnualUSD,
+    mantenimiento,
+    inversionAño1,
+    recurrenteAnual,
+    beneficioAnual,
+    beneficioTotal3a: beneficioAnual * 3,
+    VPN,
+    ROI,
+    ROI1a,
+    paybackMeses,
+    ahorroProductividad,
+    ahorroErrores,
+    ahorroHorasExtra,
+    multasRecuperadas,
+    costoHora,
+    totalHorasMes,
+  };
+}
+
+export const fmtMoney = (n) => `$${Math.round(n || 0).toLocaleString("en-US")}`;
+export const fmtPct   = (n) => `${(n || 0).toFixed(1)}%`;
+
+// Lee los parámetros de la URL y devuelve los valores válidos para el form,
+// más si venía un costo de licencias explícito (valor personalizado).
+export function parseParams(search) {
+  const p = new URLSearchParams(search);
+  const values = {};
+  SHAREABLE_NUM.forEach((k) => {
+    const raw = p.get(k);
+    if (raw !== null) {
+      const v = parseFloat(raw);
+      if (Number.isFinite(v)) values[k] = v;
+    }
+  });
+  // Compatibilidad con enlaces antiguos.
+  const legacy = {
+    peopleInProcess: "personas",
+    hoursPerDay: "horasDia",
+    avgMonthlyCostPerPerson: "salario",
+  };
+  Object.entries(legacy).forEach(([param, field]) => {
+    const v = parseFloat(p.get(param));
+    if (Number.isFinite(v)) values[field] = v;
+  });
+  const desc = p.get("descripcion");
+  if (desc) values.descripcion = desc;
+  const herr = p.get("herramienta");
+  if (herr && TOOL_KEYS.includes(herr)) values.herramienta = herr;
+
+  return { values, hasLicencias: "licenciasAnual" in values };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -971,6 +971,9 @@
       "OCorp": "Corporate bot management"
     },
     "footer": "© {year} Robotipy. Automation ROI calculator. Standard return calculation methodology.",
+    "report": {
+      "back": "Back to the calculator"
+    },
     "lead": {
       "title": "Email me the report",
       "subtitle": "Enter your details and we'll send the full analysis.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -971,6 +971,9 @@
       "OCorp": "Gestión corporativa"
     },
     "footer": "© {year} Robotipy. Calculadora de ROI de automatización. Metodología estándar de cálculo de retorno.",
+    "report": {
+      "back": "Volver a la calculadora"
+    },
     "lead": {
       "title": "Recibe el reporte por email",
       "subtitle": "Ingresa tus datos y te enviamos el análisis detallado.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -971,6 +971,9 @@
       "OCorp": "Gestão corporativa"
     },
     "footer": "© {year} Robotipy. Calculadora de ROI de automação. Metodologia padrão de cálculo de retorno.",
+    "report": {
+      "back": "Voltar à calculadora"
+    },
     "lead": {
       "title": "Receba o relatório por email",
       "subtitle": "Digite seus dados e enviaremos a análise detalhada.",


### PR DESCRIPTION
## Problema

El botón "Descargar PDF" llamaba a `window.print()` sobre toda la página de la calculadora: salía el header, el menú de navegación, el footer y la sección de FAQ en el PDF. Se veía mal.

## Solución

"Descargar PDF" ahora abre una **URL limpia** `/roi-calculator/report?<parámetros>` que contiene **solo el reporte** y se auto-imprime al cargar:
- ROI a 3 años (hero), métricas (ahorro anual, payback, ROI 1 año, VPN).
- Tablas de beneficios anuales e inversión.
- Fórmula y marca Robotipy. Diseño claro (fondo blanco, print-friendly), con CSS `@media print` que oculta el widget de chat y los botones.
- Botones (solo en pantalla, no en el PDF): "Descargar PDF" e "Volver a la calculadora".

La ruta es **noindex** (utilidad, no contenido para buscadores).

## Refactor

Se extrae la lógica de cálculo a `libs/roi.js` (`computeROI`, `fmtMoney`, `fmtPct`, `DEFAULT_FORM`, `SHAREABLE_NUM`, `TOOL_KEYS`, `parseParams`) para compartirla entre el wizard (`page.js`) y la vista de reporte sin duplicar fórmulas. El botón "Copiar enlace del resultado" sigue apuntando a la calculadora (wizard prefijado), el de PDF al `/report`.

## Archivos
- `libs/roi.js` (nuevo): cálculo + parseo de parámetros compartido.
- `components/ROIReport.js` (nuevo): vista cliente del reporte, auto-print.
- `app/[locale]/roi-calculator/report/page.js` (nuevo): ruta server, metadata noindex.
- `app/[locale]/roi-calculator/page.js`: importa desde `libs/roi`, el botón PDF abre `/report`.
- `messages/{es,en,pt}.json`: nueva clave `roiCalculator.report.back`.

## Validación
- `next build` OK: compila, TypeScript, y prerender de `/roi-calculator/report` en los 3 locales. El único error sin key dummy es `/api/client` por `RESEND_API_KEY` ausente en el entorno, ajeno a este cambio.
- JSON válidos y con claves idénticas en es/en/pt. Sin em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_