### PR TITLE
Ajustar copy del post de reportes Excel para sonar menos a IA

### DIFF
--- a/app/[locale]/blog/_assets/posts/como-automatizar-reportes-excel.js
+++ b/app/[locale]/blog/_assets/posts/como-automatizar-reportes-excel.js
@@ -215,24 +215,18 @@ export const post = {
           <IntLink href="/monitor">Robotipy Monitor</IntLink>.
         </p>
         <p className={styles.p}>
-          Para los clientes que operan sus propios robots, eso es la diferencia
-          entre un problema resuelto en veinte minutos y un escalado que llega a
-          las 10 AM cuando ya perdiste la reunión.
+          Para los clientes que operan sus propios robots, eso significa que a
+          las 7 AM del martes ya saben qué falló y pueden resolverlo solos.
         </p>
       </section>
 
       <section className="space-y-3">
         <h2 className={styles.h2}>Antes de hablar con nosotros</h2>
         <p className={styles.p}>
-          Si estás evaluando si tu reporte tiene potencial de automatización, hay
-          tres preguntas que vale responder primero: ¿Cuántas veces por semana se
-          ejecuta? ¿La estructura (columnas, fuentes, lógica de cálculo) es la
-          misma desde hace seis meses? ¿Hay una persona que es la única que sabe
-          hacerlo?
-        </p>
-        <p className={styles.p}>
-          Si respondiste &quot;más de una vez&quot;, &quot;sí&quot; y
-          &quot;sí&quot;, probablemente vale la pena explorarlo.
+          El indicio más simple: si hay alguien en tu equipo que es el único que
+          sabe hacer ese reporte, ese proceso es candidato. Cuando esa persona se
+          va de vacaciones y nadie más puede cubrirla, ya tienes el business
+          case.
         </p>
       </section>
 


### PR DESCRIPTION
## Qué cambia

Dos ajustes de copy en el post `como-automatizar-reportes-excel` para eliminar estructuras típicas de texto generado por IA.

### 1. Contraste dramático "la diferencia entre X y Y"
- Antes: "eso es la diferencia entre un problema resuelto en veinte minutos y un escalado que llega a las 10 AM cuando ya perdiste la reunión."
- Ahora: "eso significa que a las 7 AM del martes ya saben qué falló y pueden resolverlo solos."

Más llano, sin el kicker cinematográfico. El punto ya estaba hecho antes.

### 2. Framework de tres preguntas simétricas + remate espejo
- Antes: tres preguntas balanceadas ("¿Cuántas veces...? ¿La estructura...? ¿Hay una persona...?") cerradas con "Si respondiste X, Y y Z".
- Ahora: un filtro directo, una sola idea. "Si hay alguien en tu equipo que es el único que sabe hacer ese reporte, ese proceso es candidato. Cuando esa persona se va de vacaciones y nadie más puede cubrirla, ya tienes el business case."

Además hace callback al gancho de la intro (la persona que se va de vacaciones).

## Validación
- `next build` OK. Sin em-dashes, tuteo neutro (voseo de la referencia adaptado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_