### PR TITLE
Traducir la UI del blog por idioma (hero, nav y metadata)

### DIFF
--- a/app/[locale]/blog/_assets/components/HeaderBlog.js
+++ b/app/[locale]/blog/_assets/components/HeaderBlog.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { Popover, Transition } from "@headlessui/react";
 import Link from "next/link";
 import Image from "next/image";
@@ -10,18 +11,8 @@ import config from "@/config";
 import { categories } from "../categories.js";
 import ButtonSignin from "@/components/ButtonSignin";
 
-const links = [
-  {
-    href: "/blog/",
-    label: "Todos los Posts",
-  },
-];
-
-const cta = (
-  <ButtonSignin text="Contáctanos" extraStyle="btn-white md:btn-sm" />
-);
-
 const ButtonPopoverCategories = () => {
+  const t = useTranslations("blog");
   return (
     <Popover className="relative z-30">
       {({ open }) => (
@@ -30,7 +21,7 @@ const ButtonPopoverCategories = () => {
             className="link no-underline flex flex-nowrap items-center gap-1 text-white hover:text-white/70 active:text-white focus:text-white duration-100"
             title="Abrir categorías del blog"
           >
-            Categorías
+            {t("nav.categories")}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 20 20"
@@ -88,6 +79,7 @@ const ButtonPopoverCategories = () => {
 };
 
 const ButtonAccordionCategories = () => {
+  const t = useTranslations("blog");
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -101,7 +93,7 @@ const ButtonAccordionCategories = () => {
         type="button"
         className="link no-underline flex justify-between items-center w-full text-white"
       >
-        Categories
+        {t("nav.categories")}
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
@@ -140,8 +132,12 @@ const ButtonAccordionCategories = () => {
 // By default it shows the logo, the links, and the CTA.
 // In the links, there's a popover with the categories.
 const HeaderBlog = () => {
+  const t = useTranslations("blog");
   const searchParams = useSearchParams();
   const [isOpen, setIsOpen] = useState(false);
+
+  const links = [{ href: "/blog/", label: t("nav.allPosts") }];
+  const cta = <ButtonSignin text={t("nav.contact")} extraStyle="btn-white md:btn-sm" />;
 
   // setIsOpen(false) when the route changes (i.e: when the user clicks on a link on mobile)
   useEffect(() => {

--- a/app/[locale]/blog/page.js
+++ b/app/[locale]/blog/page.js
@@ -1,3 +1,4 @@
+import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
 import { getArticlesByLocale } from "./_assets/content";
 import { categories } from "./_assets/categories.js";
@@ -27,15 +28,20 @@ const EMPTY_COPY = {
   },
 };
 
-export const metadata = getSEOTags({
-  title: `Blog de ${config.appName} | Automatización de Procesos, Inteligencia Artificial y Desarrollo de Software`,
-  description:
-    "Descubre cómo optimizar y automatizar los procesos de tu empresa para maximizar la eficiencia y construir soluciones que impulsen tu crecimiento empresarial",
-  canonicalUrlRelative: "/blog",
-});
+export async function generateMetadata({ params }) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "blog" });
+  return getSEOTags({
+    locale,
+    title: `${t("heroTitle", { appName: config.appName })} | ${config.appName}`,
+    description: t("heroSubtitle"),
+    canonicalUrlRelative: "/blog",
+  });
+}
 
 export default async function Blog({ params }) {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "blog" });
   const articlesToDisplay = getArticlesByLocale(locale).sort(
     (a, b) => new Date(b.publishedAt) - new Date(a.publishedAt)
   );
@@ -51,15 +57,13 @@ export default async function Blog({ params }) {
     <div className="mx-auto max-w-[1140px] px-6 py-16">
       <section className="mx-auto mb-16 max-w-3xl text-center md:mb-24">
         <div className="mb-4 font-display text-xs font-semibold uppercase tracking-[0.14em] text-accent">
-          Blog
+          {t("eyebrow")}
         </div>
         <h1 className="mb-5 font-display text-[clamp(32px,4.5vw,50px)] font-extrabold leading-[1.05] tracking-[-0.02em] text-white">
-          El Blog de {config.appName}
+          {t("heroTitle", { appName: config.appName })}
         </h1>
         <p className="text-[18px] leading-[1.6] text-white/70">
-          Descubre cómo optimizar y automatizar los procesos de tu empresa para
-          maximizar la eficiencia y construir soluciones que impulsen tu
-          crecimiento empresarial.
+          {t("heroSubtitle")}
         </p>
       </section>
 
@@ -94,7 +98,7 @@ export default async function Blog({ params }) {
       {usedCategories.length > 0 && (
         <section>
           <h2 className="mb-8 text-center font-display text-2xl font-extrabold text-white md:mb-12 lg:text-3xl">
-            Explora los artículos por categoría
+            {t("categoriesHeading")}
           </h2>
           <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
             {usedCategories.map((category) => (

--- a/messages/en.json
+++ b/messages/en.json
@@ -1026,6 +1026,17 @@
       }
     }
   },
+  "blog": {
+    "eyebrow": "Blog",
+    "heroTitle": "The {appName} Blog",
+    "heroSubtitle": "Learn how to optimize and automate your company's processes to maximize efficiency and build solutions that drive your business growth.",
+    "categoriesHeading": "Browse articles by category",
+    "nav": {
+      "allPosts": "All Posts",
+      "categories": "Categories",
+      "contact": "Contact us"
+    }
+  },
   "successCases": {
     "hero": {
       "title": "All our success cases",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1026,6 +1026,17 @@
       }
     }
   },
+  "blog": {
+    "eyebrow": "Blog",
+    "heroTitle": "El Blog de {appName}",
+    "heroSubtitle": "Descubre cómo optimizar y automatizar los procesos de tu empresa para maximizar la eficiencia y construir soluciones que impulsen tu crecimiento empresarial.",
+    "categoriesHeading": "Explora los artículos por categoría",
+    "nav": {
+      "allPosts": "Todos los Posts",
+      "categories": "Categorías",
+      "contact": "Contáctanos"
+    }
+  },
   "successCases": {
     "hero": {
       "title": "Todos nuestros casos de éxito",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1026,6 +1026,17 @@
       }
     }
   },
+  "blog": {
+    "eyebrow": "Blog",
+    "heroTitle": "O Blog da {appName}",
+    "heroSubtitle": "Descubra como otimizar e automatizar os processos da sua empresa para maximizar a eficiência e construir soluções que impulsionem o crescimento do seu negócio.",
+    "categoriesHeading": "Explore os artigos por categoria",
+    "nav": {
+      "allPosts": "Todos os Posts",
+      "categories": "Categorias",
+      "contact": "Fale conosco"
+    }
+  },
   "successCases": {
     "hero": {
       "title": "Todos os nossos casos de sucesso",


### PR DESCRIPTION
## Problema

La interfaz del blog estaba hardcodeada en español en todos los idiomas: en `/en/blog` y `/pt/blog` el título seguía diciendo "El Blog de Robotipy", el subtítulo, "Explora los artículos por categoría" y el menú ("Todos los Posts", "Categorías", "Contáctanos") también. (El menú mobile incluso mezclaba un "Categories" suelto en inglés.)

## Solución

Nuevo namespace `blog` en `messages/{es,en,pt}.json` y localización con next-intl de:
- **Índice del blog** (`app/[locale]/blog/page.js`): eyebrow, título (`El Blog de {appName}` / `The {appName} Blog` / `O Blog da {appName}`), subtítulo y "Explora los artículos por categoría".
- **HeaderBlog** (`app/[locale]/blog/_assets/components/HeaderBlog.js`): "Todos los Posts", "Categorías" (desktop y mobile, ahora consistente) y el CTA "Contáctanos".
- **Metadata del blog**: pasa de un `export const metadata` estático en español a `generateMetadata` locale-aware (title y description traducidos + canonical y hreflang por locale).

El empty-state que agregamos antes sigue igual. En español no cambia nada visible.

## Validación
- `next build` OK. Verificado en el HTML prerenderizado:
  - `/en/blog`: "The Robotipy Blog" + "Browse articles by category".
  - `/es/blog`: "El Blog de Robotipy" + "Explora los artículos por categoría".
  - `/pt/blog`: "O Blog da Robotipy" + "Explore os artigos por categoria".
- JSON válidos en los 3 idiomas.

## Nota
Los **títulos y descripciones de los posts** siguen en español (el contenido se escribe en español). Esto traduce el *chrome* del blog, no los artículos, que en en/pt siguen mostrando el aviso con enlace a la versión en español.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_