### PR TITLE
Blog de un solo idioma en /blog (redirigir /es|/en|/pt/blog)

### DIFF
--- a/app/[locale]/blog/[articleId]/page.js
+++ b/app/[locale]/blog/[articleId]/page.js
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }) {
 
   return getSEOTags({
     locale,
-    availableLocales: ["es"],
+    localePrefix: false,
     title: article.title,
     description: article.description,
     canonicalUrlRelative: `/blog/${article.slug}`,

--- a/app/[locale]/blog/author/[authorId]/page.js
+++ b/app/[locale]/blog/author/[authorId]/page.js
@@ -11,7 +11,7 @@ export async function generateMetadata({ params }) {
 
   return getSEOTags({
     locale,
-    availableLocales: ["es"],
+    localePrefix: false,
     title: `${author.name}, autor en el Blog de ${config.appName}`,
     description: `${author.name}, autor en el Blog de ${config.appName}`,
     canonicalUrlRelative: `/blog/author/${author.slug}`,

--- a/app/[locale]/blog/category/[categoryId]/page.js
+++ b/app/[locale]/blog/category/[categoryId]/page.js
@@ -11,7 +11,7 @@ export async function generateMetadata({ params }) {
 
   return getSEOTags({
     locale,
-    availableLocales: ["es"],
+    localePrefix: false,
     title: `${category.title} | Blog de ${config.appName}`,
     description: category.description,
     canonicalUrlRelative: `/blog/category/${category.slug}`,

--- a/app/[locale]/blog/page.js
+++ b/app/[locale]/blog/page.js
@@ -33,6 +33,7 @@ export async function generateMetadata({ params }) {
   const t = await getTranslations({ locale, namespace: "blog" });
   return getSEOTags({
     locale,
+    localePrefix: false,
     title: `${t("heroTitle", { appName: config.appName })} | ${config.appName}`,
     description: t("heroSubtitle"),
     canonicalUrlRelative: "/blog",

--- a/libs/seo.js
+++ b/libs/seo.js
@@ -5,12 +5,22 @@ const siteOrigin =
   process.env.SITE_URL ||
   `https://www.${config.domainName.replace(/^www\./, "")}`;
 
-const buildAlternates = (locale, canonicalUrlRelative, availableLocales) => {
+const buildAlternates = (
+  locale,
+  canonicalUrlRelative,
+  availableLocales,
+  localePrefix = true
+) => {
   if (!canonicalUrlRelative) return undefined;
   const path = canonicalUrlRelative.startsWith("/")
     ? canonicalUrlRelative
     : `/${canonicalUrlRelative}`;
   const suffix = path === "/" ? "" : path;
+  // Páginas fuera del sistema de idiomas (el blog vive en /blog sin prefijo):
+  // canonical absoluto sin locale y sin hreflang.
+  if (localePrefix === false) {
+    return { canonical: `${siteOrigin}${suffix}` };
+  }
   // Only emit hreflang for locales where the page actually exists, so
   // single-language pages (e.g. es-only blog posts) don't point hreflang at
   // /en or /pt URLs that would 404.
@@ -47,6 +57,7 @@ export const getSEOTags = ({
   locale,
   availableLocales,
   ogLocale,
+  localePrefix,
 } = {}) => {
   const activeLocale =
     locale && routing.locales.includes(locale) ? locale : routing.defaultLocale;
@@ -120,7 +131,8 @@ export const getSEOTags = ({
       alternates: buildAlternates(
         activeLocale,
         canonicalUrlRelative,
-        availableLocales
+        availableLocales,
+        localePrefix
       ),
     }),
 

--- a/middleware.js
+++ b/middleware.js
@@ -7,6 +7,24 @@ const intlMiddleware = createMiddleware(routing);
 const MARKDOWN_ACCEPT = /(^|,\s*)text\/markdown(\s*;|\s*,|\s*$)/i;
 
 export default function middleware(request) {
+  const { pathname } = request.nextUrl;
+
+  // El blog es de un solo idioma y vive en /blog (sin prefijo de locale).
+  // 1) Redirigimos las variantes con prefijo (/es|/en|/pt/blog...) a /blog...
+  const localizedBlog = pathname.match(/^\/(?:es|en|pt)\/blog(\/.*)?$/);
+  if (localizedBlog) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/blog${localizedBlog[1] || ""}`;
+    return NextResponse.redirect(url, 308);
+  }
+  // 2) Servimos /blog reescribiendo internamente al render en español, sin
+  //    tocar la URL pública ni pasar por el middleware de i18n.
+  if (pathname === "/blog" || pathname.startsWith("/blog/")) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/es${pathname}`;
+    return NextResponse.rewrite(url);
+  }
+
   const accept = request.headers.get("accept") || "";
   if (request.method === "GET" && MARKDOWN_ACCEPT.test(accept)) {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## Objetivo

El blog debe ser de un solo idioma y vivir en **`/blog`** (sin prefijo de locale). Cualquiera que entre a `/es/blog`, `/en/blog` o `/pt/blog` debe redirigir al blog normal.

## Enfoque (mínimo riesgo, sin mover archivos)

En vez de sacar el blog del sistema de idiomas (mover 43 archivos + refactor del layout raíz), se resuelve en el **middleware**:

1. **Redirect 308** de `^/(es|en|pt)/blog(/.*)?$` → `/blog$1`. Las tres variantes con prefijo mandan al blog sin prefijo.
2. **Rewrite interno** de `/blog` y `/blog/*` → `/es/blog*`. Sirve el render en español sin cambiar la URL pública ni pasar por el middleware de i18n. (Si next-intl no detecta locale, cae a `defaultLocale = es`, que es justo lo que queremos.)

El resto del sitio conserva su esquema `[locale]` intacto.

## SEO

- Nueva opción `localePrefix: false` en `getSEOTags` (`libs/seo.js`): el canonical queda **sin** prefijo de locale (`https://www.robotipy.com/blog/...`) y sin `hreflang` (una sola URL).
- Aplicada en las 4 páginas del blog (índice, artículo, categoría, autor). El JSON-LD de los artículos ya usaba URLs sin prefijo, así que queda coherente.

## Validación (server de producción local, curl)

| Ruta | Resultado |
| --- | --- |
| `/blog` | 200 |
| `/blog/cuanto-cuesta-automatizar-un-proceso` | 200 |
| `/blog/category/RPA`, `/blog/author/danilo-toro` | 200 |
| `/es/blog` | 308 → `/blog` |
| `/en/blog`, `/pt/blog` | 308 → `/blog` |
| `/es/blog/<post>` y `/es/blog/category/RPA` | 308 → `/blog/...` |
| `/es` (home), `/` | 200 / 307 → `/es` (sitio intacto) |

Canonical verificado en el HTML: `/blog`, `/blog/<post>`, `/blog/category/RPA` (todos sin `/es`). Build OK.

## Notas
- **Enlaces internos** del sitio (Header/Footer usan el `Link` de next-intl) apuntan a `/es/blog` y ahora hacen un salto 308 a `/blog`. Funciona y es SEO-safe (redirect permanente); si quieres, en otro PR los dejo apuntando directo a `/blog` para evitar el hop.
- Con el blog en un solo idioma, la traducción del chrome (PR #56) queda inactiva (siempre renderiza español); no molesta. Se puede limpiar aparte.
- **Follow-up no relacionado:** una categoría inexistente (slug mal escrito) devuelve 500 en vez de 404. Es un bug preexistente en la página de categoría; lo puedo arreglar en un PR aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_