### PR TITLE
Redirigir a /es las páginas sin traducción real (/en, /pt)

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -9,6 +9,18 @@ const MARKDOWN_ACCEPT = /(^|,\s*)text\/markdown(\s*;|\s*,|\s*$)/i;
 export default function middleware(request) {
   const { pathname } = request.nextUrl;
 
+  // Páginas que hoy solo tienen contenido en español (sin traducción real a
+  // en/pt). Redirigimos sus variantes /en y /pt a /es con 301 para no dejar
+  // duplicados finos indexados. Se pueden re-activar cuando haya traducción.
+  const esOnly = pathname.match(
+    /^\/(?:en|pt)\/(ai-info|automation|casos-exito|chatbot|industries|portafolio|privacy-policy|services|success-cases|tos)(\/.*)?$/
+  );
+  if (esOnly) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/es/${esOnly[1]}${esOnly[2] || ""}`;
+    return NextResponse.redirect(url, 301);
+  }
+
   // El blog es de un solo idioma y vive en /blog (sin prefijo de locale).
   // 1) Redirigimos las variantes con prefijo (/es|/en|/pt/blog...) a /blog...
   const localizedBlog = pathname.match(/^\/(?:es|en|pt)\/blog(\/.*)?$/);


### PR DESCRIPTION
## Contexto

Revisión del CSV de "Failing URLs" de Search Console. Clasificando las 46 URLs:

- **Blog (12):** ya resueltas por el PR #57 (mergeado). `/es|/en|/pt/blog/*` → 308 → `/blog/*`, sin hreflang. Caen del índice al recrawlear.
- **Substack (3):** `newsletter.robotipy.com/*`, externo, no es este repo.
- **Resto (31):** duplicados por prefijo/idioma. Este PR ataca la parte accionable y confirmada.

## Qué hace este PR

Redirige con **301** las variantes `/en/*` y `/pt/*` de las páginas que **hoy solo tienen contenido en español** (sin traducción real) a su versión `/es/*`. Eran duplicados finos indexados por Google.

Rutas afectadas: `ai-info`, `automation`, `casos-exito`, `chatbot`, `industries`, `portafolio`, `privacy-policy`, `services`, `success-cases`, `tos`.

**No se tocan** las páginas realmente traducidas, que siguen sirviendo `/en` y `/pt` con 200: `monitor`, `analysis`, `projects` (y subpáginas), `rocketbot`, `about`, `capacitaciones`, `contact-us`, `desarrollo-software`, `rpa`, `roi-calculator`, home.

## Validación (server de producción local)

- No traducidas: `/en/automation`, `/en/portafolio`, `/en/casos-exito/seguros`, `/en/industries/agtech`, `/en/success-cases`, `/en/chatbot`, `/en/ai-info`, `/en/tos`, `/en/privacy-policy`, `/pt/automation` → **301 → `/es/...`**.
- Traducidas: `/en/monitor`, `/en/analysis`, `/en/rocketbot`, `/en/projects`, `/en/about`, `/pt/monitor` → **200** (sin redirect).
- `/es/*` de las no traducidas → **200**. Reglas del blog (#57) intactas.

## Notas importantes (contexto para vos)

1. **`/en/monitor`, `/en/analysis`, `/en/projects` NO están rotas en el código.** Ya tienen meta y cuerpo en inglés real (ej. `monitor/layout.js` tiene `META` en es/en/pt). El español que muestra el CSV es **caché viejo de Google** (export previo a esas traducciones); se corrige solo al recrawlear.
2. **URLs sin prefijo** (`/about`, `/automation`, `/portafolio`, etc.): según tu decisión, **no se tocan** en este PR.
3. **Blog:** ya está consolidado en `/blog` por #57. No se revierte a `/es/blog` (sería flip-flop del canonical, dañino) porque #57 ya resuelve esas filas del CSV sin hreflang roto.
4. Después de mergear, conviene pedir **re-crawl en Search Console** de las URLs afectadas para que Google actualice más rápido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfXtKRTFZvvFuMZFrEx5oZ)_