### PR TITLE
Botón de WhatsApp en el formulario de contacto

### DIFF
--- a/components/ClientForm.js
+++ b/components/ClientForm.js
@@ -9,6 +9,12 @@ import config from "@/config";
 
 const CALENDAR_REDIRECT_URL = "https://calendar.app.google/KE5eYDUF4qy11yVz9";
 
+// WhatsApp de contacto directo (opción para quien prefiere no llenar el form).
+const WHATSAPP_NUMBER = "56999611040";
+const WHATSAPP_URL = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(
+  "Hola, vengo desde la web de Robotipy y me gustaría más información."
+)}`;
+
 /** Meta Pixel CompleteRegistration — id matches partner snippet (DOM / GTM). */
 function trackContactCompleteRegistration() {
   if (typeof window !== "undefined" && typeof window.fbq === "function") {
@@ -435,6 +441,25 @@ const ClientForm = ({ extraStyle, initialValues = {} }) => {
             <p className="text-cyan-400 text-xs text-center mt-3">
               {t("trustLine")}
             </p>
+
+            {/* Opción de WhatsApp: captura a quien prefiere chatear en vez de
+                llenar el formulario (muy común en LatAm). */}
+            <div className="flex items-center gap-3 my-5" aria-hidden="true">
+              <span className="h-px flex-1 bg-cyan-800/40"></span>
+              <span className="text-cyan-400 text-xs">{t("whatsapp.divider")}</span>
+              <span className="h-px flex-1 bg-cyan-800/40"></span>
+            </div>
+            <a
+              href={WHATSAPP_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full flex items-center justify-center gap-2 bg-[#25D366] hover:bg-[#1ebe5d] text-white py-3 px-6 rounded-md transition-colors duration-200 font-semibold focus:outline-none focus:ring-2 focus:ring-[#25D366] focus:ring-offset-2"
+            >
+              <svg viewBox="0 0 32 32" width="20" height="20" fill="currentColor" aria-hidden="true">
+                <path d="M16.003 3.2c-7.06 0-12.8 5.74-12.8 12.8 0 2.257.59 4.46 1.71 6.402L3.2 28.8l6.56-1.68a12.74 12.74 0 006.243 1.6h.005c7.06 0 12.8-5.74 12.8-12.8 0-3.42-1.332-6.635-3.75-9.052A12.72 12.72 0 0016.003 3.2zm0 23.04h-.004a10.6 10.6 0 01-5.4-1.48l-.388-.23-4.03 1.03 1.075-3.93-.253-.403a10.59 10.59 0 01-1.62-5.63c0-5.865 4.774-10.64 10.643-10.64 2.842 0 5.514 1.108 7.523 3.12a10.57 10.57 0 013.117 7.527c0 5.865-4.774 10.64-10.64 10.64zm5.834-7.968c-.32-.16-1.892-.933-2.185-1.04-.293-.107-.507-.16-.72.16-.213.32-.826 1.04-1.013 1.253-.187.213-.373.24-.693.08-.32-.16-1.35-.498-2.572-1.587-.95-.848-1.592-1.895-1.778-2.215-.187-.32-.02-.493.14-.653.144-.143.32-.373.48-.56.16-.187.213-.32.32-.533.107-.213.053-.4-.027-.56-.08-.16-.72-1.734-.986-2.374-.26-.623-.523-.538-.72-.548l-.613-.01c-.213 0-.56.08-.853.4-.293.32-1.12 1.093-1.12 2.667 0 1.573 1.146 3.093 1.306 3.307.16.213 2.253 3.44 5.457 4.823.763.33 1.358.527 1.822.674.766.243 1.463.209 2.014.127.615-.092 1.892-.773 2.158-1.52.267-.747.267-1.387.187-1.52-.08-.133-.293-.213-.613-.373z"/>
+              </svg>
+              {t("whatsapp.button")}
+            </a>
           </div>
         </form>
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -387,6 +387,10 @@
       "chatbot": "AI chatbots",
       "capacitacion": "Training",
       "otro": "Other / not sure yet"
+    },
+    "whatsapp": {
+      "divider": "or if you prefer",
+      "button": "Message us on WhatsApp"
     }
   },
   "about": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -387,6 +387,10 @@
       "chatbot": "Chatbots con IA",
       "capacitacion": "Capacitación",
       "otro": "Otro / no estoy seguro"
+    },
+    "whatsapp": {
+      "divider": "o si prefieres",
+      "button": "Escríbenos por WhatsApp"
     }
   },
   "about": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -387,6 +387,10 @@
       "chatbot": "Chatbots com IA",
       "capacitacion": "Treinamento",
       "otro": "Outro / ainda não sei"
+    },
+    "whatsapp": {
+      "divider": "ou se preferir",
+      "button": "Fale conosco no WhatsApp"
     }
   },
   "about": {


### PR DESCRIPTION
Agrega una opción de contacto por WhatsApp (+56 9 9961 1040) al final del formulario, separada con un divisor "o si prefieres".

**Por qué:** en LatAm muchos decisores prefieren escribir por WhatsApp antes que llenar un formulario. Esta opción captura leads que hoy se pierden por completo.

- Botón verde con ícono de WhatsApp, ancho completo, debajo del CTA de agendar
- Link directo con mensaje prellenado
- Textos en es/en/pt
- Build verificado

🤖 Generated with [Claude Code](https://claude.com/claude-code)