### PR TITLE
CTA pegajoso en celular

### DIFF
--- a/app/[locale]/contact-us/page.js
+++ b/app/[locale]/contact-us/page.js
@@ -27,6 +27,10 @@ function MinimalHeader() {
 //   2) fbclid presente (tráfico de Meta Ads sin parámetro): automatización,
 //      porque las campañas activas hoy venden automatización
 //   3) sin nada: primero se pregunta "¿Qué te interesa?" (selector de servicios)
+const WHATSAPP_URL =
+  "https://wa.me/56999611040?text=" +
+  encodeURIComponent("Hola, vengo desde la web de Robotipy y me gustaría más información.");
+
 const SERVICE_VARIANTS = ["automatizacion", "software", "chatbot", "capacitacion"];
 const CHOOSER_OPTIONS = ["automatizacion", "software", "chatbot", "capacitacion", "otro"];
 const VARIANT_TO_INTEREST = {
@@ -113,7 +117,7 @@ function ContactUsContent() {
           "desconectado" resta confianza y distrae de la única acción (el form). */}
       <style>{`#zsiq_float { display: none !important; }`}</style>
       <main id="main-content">
-        <section className="min-h-screen flex flex-col items-center px-4 pb-20 lg:px-8 background-image">
+        <section className="min-h-screen flex flex-col items-center px-4 pb-28 lg:pb-20 lg:px-8 background-image">
           <MinimalHeader />
           <div className="flex flex-col gap-10 lg:gap-14 items-center max-w-6xl mx-auto text-center text-white pt-10 lg:pt-16">
             {showChooser ? (
@@ -179,6 +183,35 @@ function ContactUsContent() {
             </div>
           </div>
         </section>
+
+        {/* CTA pegajoso en celular: mantiene la acción principal siempre a la
+            vista mientras el visitante scrollea. Oculto en desktop. */}
+        {!showChooser && !submitted && (
+          <div
+            className="lg:hidden fixed inset-x-0 bottom-0 z-40 border-t border-cyan-800/40 bg-[#0a1622]/95 backdrop-blur px-4 pt-3"
+            style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 0.75rem)" }}
+          >
+            <div className="flex items-center gap-2 max-w-2xl mx-auto">
+              <a
+                href="#form"
+                className="flex-1 text-center bg-teal-500 hover:bg-teal-600 text-white py-3 px-4 rounded-md font-semibold"
+              >
+                {t("stickyCta")}
+              </a>
+              <a
+                href={WHATSAPP_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="WhatsApp"
+                className="flex-none w-12 h-12 flex items-center justify-center bg-[#25D366] rounded-md text-white"
+              >
+                <svg viewBox="0 0 32 32" width="24" height="24" fill="currentColor" aria-hidden="true">
+                  <path d="M16.003 3.2c-7.06 0-12.8 5.74-12.8 12.8 0 2.257.59 4.46 1.71 6.402L3.2 28.8l6.56-1.68a12.74 12.74 0 006.243 1.6h.005c7.06 0 12.8-5.74 12.8-12.8 0-3.42-1.332-6.635-3.75-9.052A12.72 12.72 0 0016.003 3.2zm0 23.04h-.004a10.6 10.6 0 01-5.4-1.48l-.388-.23-4.03 1.03 1.075-3.93-.253-.403a10.59 10.59 0 01-1.62-5.63c0-5.865 4.774-10.64 10.643-10.64 2.842 0 5.514 1.108 7.523 3.12a10.57 10.57 0 013.117 7.527c0 5.865-4.774 10.64-10.64 10.64zm5.834-7.968c-.32-.16-1.892-.933-2.185-1.04-.293-.107-.507-.16-.72.16-.213.32-.826 1.04-1.013 1.253-.187.213-.373.24-.693.08-.32-.16-1.35-.498-2.572-1.587-.95-.848-1.592-1.895-1.778-2.215-.187-.32-.02-.493.14-.653.144-.143.32-.373.48-.56.16-.187.213-.32.32-.533.107-.213.053-.4-.027-.56-.08-.16-.72-1.734-.986-2.374-.26-.623-.523-.538-.72-.548l-.613-.01c-.213 0-.56.08-.853.4-.293.32-1.12 1.093-1.12 2.667 0 1.573 1.146 3.093 1.306 3.307.16.213 2.253 3.44 5.457 4.823.763.33 1.358.527 1.822.674.766.243 1.463.209 2.014.127.615-.092 1.892-.773 2.158-1.52.267-.747.267-1.387.187-1.52-.08-.133-.293-.213-.613-.373z"/>
+                </svg>
+              </a>
+            </div>
+          </div>
+        )}
       </main>
     </>
   );

--- a/messages/en.json
+++ b/messages/en.json
@@ -324,7 +324,8 @@
           "desc": "Tell us your case and we will point you in the right direction."
         }
       }
-    }
+    },
+    "stickyCta": "Book your free diagnostic"
   },
   "clientForm": {
     "getInTouch": "Book your free diagnostic",

--- a/messages/es.json
+++ b/messages/es.json
@@ -324,7 +324,8 @@
           "desc": "Cuéntanos tu caso y te orientamos sin compromiso."
         }
       }
-    }
+    },
+    "stickyCta": "Agenda tu diagnóstico gratis"
   },
   "clientForm": {
     "getInTouch": "Agenda tu diagnóstico gratis",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -324,7 +324,8 @@
           "desc": "Conte seu caso e orientamos sem compromisso."
         }
       }
-    }
+    },
+    "stickyCta": "Agende seu diagnóstico grátis"
   },
   "clientForm": {
     "getInTouch": "Agende seu diagnóstico grátis",


### PR DESCRIPTION
Agrega una barra de acción fija en la parte inferior en móvil (oculta en desktop) con el CTA principal (lleva al formulario) y un botón de WhatsApp.

**Por qué:** el tráfico de anuncios es casi todo móvil; mantener la acción siempre visible mientras se scrollea sube la conversión.

- Solo móvil (lg:hidden), position fixed con safe-area padding
- Se oculta en el selector de servicio y tras enviar
- Verificado en viewport de celular

🤖 Generated with [Claude Code](https://claude.com/claude-code)